### PR TITLE
Fixing some errors so p-token builds

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -615,7 +615,11 @@ fn collect_ty(val_collector: &mut InternedValueCollector, val: stable_mir::ty::T
             let name = rustc_middle::ty::print::with_no_trimmed_paths!(val_collector
                 .tcx
                 .def_path_str(def_id_internal));
-            if *"std::fmt::Arguments" == name {
+            if *"std::fmt::Arguments" == name || *"core::fmt::Arguments" == name {
+                eprintln!(
+                    "Cannot collect Layout for Ty with escaping bound vars: {:?}",
+                    val
+                );
                 None
             } else {
                 Some(val.layout())

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -529,9 +529,11 @@ fn get_prov_type(maybe_kind: Option<stable_mir::ty::TyKind>) -> Option<stable_mi
         return ty.ty.kind().into();
     }
     match kind.rigid().expect("Non-rigid-ty allocation found!") {
-        RigidTy::Array(ty, _) | RigidTy::Slice(ty) => ty.kind().into(),
-        RigidTy::FnPtr(_) => None,
-        _ => todo!(),
+        RigidTy::Array(ty, _) | RigidTy::Slice(ty) | RigidTy::Ref(_, ty, _) => ty.kind().into(),
+        RigidTy::FnPtr(_) | RigidTy::Adt(..) => None, // TODO: Check for Adt if the GenericArgs are related to prov
+        unimplemented => {
+            todo!("Unimplemented RigidTy allocation: {:?}", unimplemented);
+        }
     }
 }
 


### PR DESCRIPTION
Currently `stable-mir-json` will not build complex programs. This PR makes some changes so that [p-token](https://github.com/febo/p-token) will build as long as [this feature flag in pinocchio](https://github.com/anza-xyz/pinocchio/blob/1a10e2277303d843e8f2922d4efab87f41d82aff/sdk/log/crate/Cargo.toml#L20) is removed (this is unneeded to build p-token so it is no problem to remove it)

- Added `Adt` and `Ref` type handling for the `RigidTy`s in `get_prov_type` as seen in #32 
- Side steps the DUMMY_BINDER escaping bound vars in formatting arguments as seen in #27 