### PR TITLE
Render projections in the SMIR graph of basic blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,9 @@ integration-test:
 
 golden:
 	make integration-test DIFF=">"
+
+format: 
+	cargo fmt
+
+style-check: format
+	cargo clippy

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -426,9 +426,9 @@ impl GraphLabelString for ProjectionElem {
             ProjectionElem::Field(i, _) => format!(".{i}"),
             ProjectionElem::Index(local) => format!("[_{local}]"),
             ProjectionElem::ConstantIndex { offset, min_length: _, from_end } =>
-                format!("[{}{}]", if from_end.clone() {"-"} else {""}, offset),
+                format!("[{}{}]", if *from_end {"-"} else {""}, offset),
             ProjectionElem::Subslice { from, to, from_end } =>
-                format!("[{}..{}{}]", from, if from_end.clone() {"-"} else {""}, to),
+                format!("[{}..{}{}]", from, if *from_end {"-"} else {""}, to),
             ProjectionElem::Downcast(i) => format!(" as {:?}", i),
             ProjectionElem::OpaqueCast(ty) => format!(" as type {}", ty),
             ProjectionElem::Subtype(i) => format!(" as {:?}", i),

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -15,7 +15,8 @@ use rustc_session::config::{OutFileName, OutputType};
 
 extern crate rustc_session;
 use stable_mir::mir::{
-    AggregateKind, BasicBlock, ConstOperand, Mutability, NonDivergingIntrinsic, NullOp, Operand, Place, ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, UnwindAction
+    AggregateKind, BasicBlock, ConstOperand, Mutability, NonDivergingIntrinsic, NullOp, Operand,
+    Place, ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, UnwindAction,
 };
 use stable_mir::ty::{IndexedVal, Ty};
 
@@ -404,18 +405,9 @@ impl GraphLabelString for Operand {
 
 impl GraphLabelString for Place {
     fn label(&self) -> String {
+        let projections: &Vec<String> = &self.projection.iter().map(|p| p.label()).collect();
 
-        let projections: &Vec<String> = 
-            &self.projection
-                .iter()
-                .map(|p| p.label())
-                .collect();
-
-        format!(
-            "_{}{}",
-            &self.local,
-            projections.join("")
-        )
+        format!("_{}{}", &self.local, projections.join(""))
     }
 }
 
@@ -425,17 +417,20 @@ impl GraphLabelString for ProjectionElem {
             ProjectionElem::Deref => "*".to_string(),
             ProjectionElem::Field(i, _) => format!(".{i}"),
             ProjectionElem::Index(local) => format!("[_{local}]"),
-            ProjectionElem::ConstantIndex { offset, min_length: _, from_end } =>
-                format!("[{}{}]", if *from_end {"-"} else {""}, offset),
-            ProjectionElem::Subslice { from, to, from_end } =>
-                format!("[{}..{}{}]", from, if *from_end {"-"} else {""}, to),
+            ProjectionElem::ConstantIndex {
+                offset,
+                min_length: _,
+                from_end,
+            } => format!("[{}{}]", if *from_end { "-" } else { "" }, offset),
+            ProjectionElem::Subslice { from, to, from_end } => {
+                format!("[{}..{}{}]", from, if *from_end { "-" } else { "" }, to)
+            }
             ProjectionElem::Downcast(i) => format!(" as {:?}", i),
             ProjectionElem::OpaqueCast(ty) => format!(" as type {}", ty),
             ProjectionElem::Subtype(i) => format!(" as {:?}", i),
         }
     }
 }
-
 
 impl GraphLabelString for AggregateKind {
     fn label(&self) -> String {

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -15,8 +15,7 @@ use rustc_session::config::{OutFileName, OutputType};
 
 extern crate rustc_session;
 use stable_mir::mir::{
-    AggregateKind, BasicBlock, ConstOperand, Mutability, NonDivergingIntrinsic, NullOp, Operand,
-    Place, Rvalue, Statement, StatementKind, TerminatorKind, UnwindAction,
+    AggregateKind, BasicBlock, ConstOperand, Mutability, NonDivergingIntrinsic, NullOp, Operand, Place, ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, UnwindAction
 };
 use stable_mir::ty::{IndexedVal, Ty};
 
@@ -405,17 +404,38 @@ impl GraphLabelString for Operand {
 
 impl GraphLabelString for Place {
     fn label(&self) -> String {
+
+        let projections: &Vec<String> = 
+            &self.projection
+                .iter()
+                .map(|p| p.label())
+                .collect();
+
         format!(
             "_{}{}",
             &self.local,
-            if !&self.projection.is_empty() {
-                "(...)"
-            } else {
-                ""
-            }
+            projections.join("")
         )
     }
 }
+
+impl GraphLabelString for ProjectionElem {
+    fn label(&self) -> String {
+        match &self {
+            ProjectionElem::Deref => "*".to_string(),
+            ProjectionElem::Field(i, _) => format!(".{i}"),
+            ProjectionElem::Index(local) => format!("[_{local}]"),
+            ProjectionElem::ConstantIndex { offset, min_length: _, from_end } =>
+                format!("[{}{}]", if from_end.clone() {"-"} else {""}, offset),
+            ProjectionElem::Subslice { from, to, from_end } =>
+                format!("[{}..{}{}]", from, if from_end.clone() {"-"} else {""}, to),
+            ProjectionElem::Downcast(i) => format!(" as {:?}", i),
+            ProjectionElem::OpaqueCast(ty) => format!(" as type {}", ty),
+            ProjectionElem::Subtype(i) => format!(" as {:?}", i),
+        }
+    }
+}
+
 
 impl GraphLabelString for AggregateKind {
     fn label(&self) -> String {


### PR DESCRIPTION
* field projections are rendered as suffix `.N` where `N` is the field index
* array indexing (constant or with a local) is rendered as `[IDX]`, where `IDX` is either a local written with `_` prefix or a plain integer
* dereferencing is rendered as a `*` suffix (NB _not_ prefix, for practicality)
* type casts and subtyping are rendered by appending `as _TYPE_`