### PR TITLE
Small tweaks to graph and installed script

### DIFF
--- a/src/bin/cargo_stable_mir_json.rs
+++ b/src/bin/cargo_stable_mir_json.rs
@@ -151,17 +151,24 @@ fn add_run_script(smir_json_dir: &Path, ld_library_path: &Path, profile: Profile
     let run_script_path = smir_json_dir.join(format!("{}.sh", profile.name()));
     let mut run_script = std::fs::File::create(&run_script_path)?;
     writeln!(run_script, "#!/bin/bash")?;
-    writeln!(run_script, "set -eu")?;
     writeln!(run_script)?;
+    writeln!(
+        run_script,
+        "# options --dot and --json can be set with this"
+    )?;
+    writeln!(run_script, "STABLE_MIR_OPTS=${{STABLE_MIR_OPTS:-''}}")?;
+    writeln!(run_script)?;
+    writeln!(run_script, "set -eu")?;
+    writeln!(run_script, "SCRIPT_DIR=$(dirname \"$(realpath $0)\")")?;
     writeln!(
         run_script,
         "export LD_LIBRARY_PATH={}",
         ld_library_path.display(),
     )?;
+    writeln!(run_script)?;
     writeln!(
         run_script,
-        "exec \"{}/{}/stable_mir_json\" \"$@\"",
-        smir_json_dir.display(),
+        "exec \"${{SCRIPT_DIR}}/{}/stable_mir_json\" ${{STABLE_MIR_OPTS}} \"$@\"",
         profile.name()
     )?;
 


### PR DESCRIPTION
Tweaks to graph rendering
* Reference creation and dereferencing are now rendered differently:
   - dereference: `& ...` or `&mut ...`, 
* operand copy and operand move are now indicated by `cp(...)` and `mv(...)`

Tweaks to installed run script:
* environment variable `STABLE_MIR_OPTS` can be set to pass `--dot` or `--json` (or any number of other options) directly to the compiler invocation
* the script now uses its location as a path prefix instead of fixing it to the installation directory, i.e., the installation can be moved to a different directory without breaking