### PR TITLE
Removed the multiple `Body`s for `Instance`

### DIFF
--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -223,7 +223,7 @@ impl SmirJson<'_> {
 
                         if let Some(body) = &body {
                             process_blocks(&mut c, 0, &body.blocks);
-                        } // TODO: Should we indicate missing `Body`?
+                        } // TODO: Investigate `MonoItem::Fn` without `Body` and make dummy node if correct
 
                         drop(c); // so we can borrow graph again
 
@@ -280,7 +280,7 @@ impl SmirJson<'_> {
 
                         if let Some(ref body) = body {
                             add_call_edges(&mut graph, 0, &body.blocks);
-                        } // TODO: Should we indicate missing `Body`?
+                        }
                     }
                     MonoItemKind::MonoItemGlobalAsm { asm } => {
                         let mut n = graph.node_named(short_name(&asm));

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -221,7 +221,10 @@ impl SmirJson<'_> {
                                 }
                             };
 
-                        process_blocks(&mut c, 0, &body.blocks);
+                        if let Some(body) = &body {
+                            process_blocks(&mut c, 0, &body.blocks);
+                        } // TODO: Should we indicate missing `Body`?
+
                         drop(c); // so we can borrow graph again
 
                         // call edges have to be added _outside_ the cluster of blocks for one function
@@ -275,7 +278,9 @@ impl SmirJson<'_> {
                                 }
                             };
 
-                        add_call_edges(&mut graph, 0, &body.blocks);
+                        if let Some(ref body) = body {
+                            add_call_edges(&mut graph, 0, &body.blocks);
+                        } // TODO: Should we indicate missing `Body`?
                     }
                     MonoItemKind::MonoItemGlobalAsm { asm } => {
                         let mut n = graph.node_named(short_name(&asm));

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -221,22 +221,7 @@ impl SmirJson<'_> {
                                 }
                             };
 
-                        match &body.len() {
-                            0 => {
-                                c.node_auto().set_label("<empty body>");
-                            }
-                            1 => {
-                                process_blocks(&mut c, 0, &body[0].blocks);
-                            }
-                            _more => {
-                                let mut curr: usize = 0;
-                                for b in &body {
-                                    let mut cc = c.cluster();
-                                    process_blocks(&mut cc, curr, &b.blocks);
-                                    curr += b.blocks.len();
-                                }
-                            }
-                        }
+                        process_blocks(&mut c, 0, &body.blocks);
                         drop(c); // so we can borrow graph again
 
                         // call edges have to be added _outside_ the cluster of blocks for one function
@@ -290,19 +275,7 @@ impl SmirJson<'_> {
                                 }
                             };
 
-                        match &body.len() {
-                            0 => {}
-                            1 => {
-                                add_call_edges(&mut graph, 0, &body[0].blocks);
-                            }
-                            _more => {
-                                let mut curr: usize = 0;
-                                for b in &body {
-                                    add_call_edges(&mut graph, curr, &b.blocks);
-                                    curr += b.blocks.len();
-                                }
-                            }
-                        }
+                        add_call_edges(&mut graph, 0, &body.blocks);
                     }
                     MonoItemKind::MonoItemGlobalAsm { asm } => {
                         let mut n = graph.node_named(short_name(&asm));

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -70,7 +70,7 @@ struct ItemDetails {
     // these fields only defined for fn items
     fn_instance_kind: Option<InstanceKind>,
     fn_item_kind: Option<ItemKind>,
-    fn_body_details: Vec<BodyDetails>,
+    fn_body_details: Option<BodyDetails>,
     // these fields defined for all items
     internal_kind: String,
     path: String,
@@ -133,12 +133,9 @@ fn get_item_details(tcx: TyCtxt<'_>, id: DefId, fn_inst: Option<Instance>) -> Op
                 .and_then(|i| CrateItem::try_from(i).ok())
                 .map(|i| i.kind()),
             fn_body_details: if let Some(fn_inst) = fn_inst {
-                get_bodies(tcx, &fn_inst)
-                    .iter()
-                    .map(get_body_details)
-                    .collect()
+                fn_inst.body().and_then(|body| Some(get_body_details(&body)))
             } else {
-                vec![]
+                None
             },
             internal_kind: format!("{:#?}", tcx.def_kind(id)),
             path: tcx.def_path_str(id), // NOTE: underlying data from tcx.def_path(id);
@@ -227,28 +224,6 @@ fn mono_item_name_int<'a>(tcx: TyCtxt<'a>, item: &rustc_middle::mir::mono::MonoI
     item.symbol_name(tcx).name.into()
 }
 
-fn get_promoted(tcx: TyCtxt<'_>, inst: &Instance) -> Vec<Body> {
-    let id = rustc_internal::internal(tcx, inst.def.def_id());
-    if inst.has_body() {
-        tcx.promoted_mir(id)
-            .into_iter()
-            .map(rustc_internal::stable)
-            .collect()
-    } else {
-        vec![]
-    }
-}
-
-fn get_bodies(tcx: TyCtxt<'_>, inst: &Instance) -> Vec<Body> {
-    if let Some(body) = inst.body() {
-        let mut bodies = get_promoted(tcx, inst);
-        bodies.insert(0, body);
-        bodies
-    } else {
-        vec![]
-    }
-}
-
 fn fn_inst_for_ty(ty: stable_mir::ty::Ty, direct_call: bool) -> Option<Instance> {
     ty.kind().fn_def().and_then(|(fn_def, args)| {
         if direct_call {
@@ -288,7 +263,7 @@ pub enum MonoItemKind {
     MonoItemFn {
         name: String,
         id: stable_mir::DefId,
-        body: Vec<Body>,
+        body: Body,
     },
     MonoItemStatic {
         name: String,
@@ -316,11 +291,11 @@ fn mk_item(tcx: TyCtxt<'_>, item: MonoItem, sym_name: String) -> Item {
             let internal_id = rustc_internal::internal(tcx, id);
             Item {
                 mono_item: item,
-                symbol_name: sym_name,
+                symbol_name: sym_name.clone(),
                 mono_item_kind: MonoItemKind::MonoItemFn {
                     name: name.clone(),
                     id,
-                    body: get_bodies(tcx, &inst),
+                    body: inst.body().expect(format!("Failed to retrive body for Instance of MonoItem::Fn {}", sym_name).as_str()),
                 },
                 details: get_item_details(tcx, internal_id, Some(inst)),
             }
@@ -771,31 +746,29 @@ fn collect_interned_values<'tcx>(tcx: TyCtxt<'tcx>, items: Vec<&MonoItem>) -> In
     for item in items.iter() {
         match &item {
             MonoItem::Fn(inst) => {
-                for body in get_bodies(tcx, inst).into_iter() {
-                    InternedValueCollector {
-                        tcx,
-                        _sym: inst.mangled_name(),
-                        locals: body.locals(),
-                        link_map: &mut calls_map,
-                        visited_tys: &mut visited_tys,
-                        visited_allocs: &mut visited_allocs,
-                    }
-                    .visit_body(&body)
+                let body = inst.body().expect(format!("Failed to retrive body for Instance of MonoItem::Fn {}", inst.name()).as_str());
+                InternedValueCollector {
+                    tcx,
+                    _sym: inst.mangled_name(),
+                    locals: body.locals(),
+                    link_map: &mut calls_map,
+                    visited_tys: &mut visited_tys,
+                    visited_allocs: &mut visited_allocs,
                 }
+                .visit_body(&body)
             }
             MonoItem::Static(def) => {
                 let inst = def_id_to_inst(tcx, def.def_id());
-                for body in get_bodies(tcx, &inst).into_iter() {
-                    InternedValueCollector {
-                        tcx,
-                        _sym: inst.mangled_name(),
-                        locals: &[],
-                        link_map: &mut calls_map,
-                        visited_tys: &mut visited_tys,
-                        visited_allocs: &mut visited_allocs,
-                    }
-                    .visit_body(&body)
+                let body = inst.body().expect(format!("Failed to retrive body for Instance of MonoItem::Fn {}", inst.name()).as_str());
+                InternedValueCollector {
+                    tcx,
+                    _sym: inst.mangled_name(),
+                    locals: &[],
+                    link_map: &mut calls_map,
+                    visited_tys: &mut visited_tys,
+                    visited_allocs: &mut visited_allocs,
                 }
+                .visit_body(&body)
             }
             MonoItem::GlobalAsm(_) => {}
         }
@@ -868,7 +841,7 @@ fn collect_unevaluated_constant_items(
 
     while let Some((curr_name, value)) = take_any(&mut pending_items) {
         // skip item if it isn't a function
-        let bodies = match value.mono_item_kind {
+        let body = match value.mono_item_kind {
             MonoItemKind::MonoItemFn { ref body, .. } => body,
             _ => continue,
         };
@@ -882,8 +855,7 @@ fn collect_unevaluated_constant_items(
             current_item: hash(&curr_name),
         };
 
-        // add each fresh collected constant to pending new items
-        bodies.iter().for_each(|body| collector.visit_body(body));
+        collector.visit_body(body);
 
         // move processed item into seen items
         processed_items.insert(curr_name.to_string(), value);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -263,7 +263,7 @@ pub enum MonoItemKind {
     MonoItemFn {
         name: String,
         id: stable_mir::DefId,
-        body: Body,
+        body: Option<Body>,
     },
     MonoItemStatic {
         name: String,
@@ -295,12 +295,7 @@ fn mk_item(tcx: TyCtxt<'_>, item: MonoItem, sym_name: String) -> Item {
                 mono_item_kind: MonoItemKind::MonoItemFn {
                     name: name.clone(),
                     id,
-                    body: inst.body().unwrap_or_else(|| {
-                        panic!(
-                            "Failed to retrive body for Instance of MonoItem::Fn {}",
-                            sym_name
-                        )
-                    }),
+                    body: inst.body(),
                 },
                 details: get_item_details(tcx, internal_id, Some(inst)),
             }
@@ -870,7 +865,9 @@ fn collect_unevaluated_constant_items(
             current_item: hash(&curr_name),
         };
 
-        collector.visit_body(body);
+        if let Some(body) = body {
+            collector.visit_body(body);
+        }
 
         // move processed item into seen items
         processed_items.insert(curr_name.to_string(), value);

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -77,356 +77,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -437,359 +435,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -800,177 +796,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -981,139 +975,137 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 45
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 45
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
                           }
                         },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 44
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 46
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 23
-                },
-                {
-                  "mutability": "Not",
-                  "span": 49,
-                  "ty": 24
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 48,
-                  "ty": 25
-                }
-              ],
-              "span": 50,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 49
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                  "span": 44
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 46
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 23
+              },
+              {
+                "mutability": "Not",
+                "span": 49,
+                "ty": 24
+              },
+              {
+                "mutability": "Mut",
+                "span": 48,
+                "ty": 25
+              }
+            ],
+            "span": 50,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 49
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 3,
           "name": "<&i32 as std::fmt::Debug>::fmt"
         }
@@ -1124,518 +1116,516 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 52
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 53
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 53
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 7,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          16,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 32,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 54
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 3,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
                         }
+                      ]
+                    },
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 7,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        16,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 26
+                                },
+                                "span": 32,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 54
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
                       }
+                    }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
                     },
                     "span": 51
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 8,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 6,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 58
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 59
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 8,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 55,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 6,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 58
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 59
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 59
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 32,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 58
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 60
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 5,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              4
-                            ]
-                          ],
-                          "otherwise": 3
                         }
+                      ]
+                    },
+                    "span": 59
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 9,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 26
+                                },
+                                "span": 32,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 58
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 60
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 5,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            4
+                          ]
+                        ],
+                        "otherwise": 3
                       }
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 5
                     },
                     "span": 57
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 5
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 28
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 28
-                            },
-                            "span": 61,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 5,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 62
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 5
+                          "span": 61,
+                          "user_ty": null
+                        }
                       },
-                      "span": 57
+                      "target": 5,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
+                      "StorageDead": 5
+                    },
+                    "span": 57
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 29
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 29
-                            },
-                            "span": 63,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 5,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 64
-                  }
+                          "span": 63,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 5,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 64
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 6
+                    }
+                  },
+                  "span": 65
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 66
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 68,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 69,
+                "ty": 24
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 26
+              }
+            ],
+            "span": 72,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 68
                 },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 6
-                      }
-                    },
-                    "span": 65
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 66
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 22
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 69
                 },
-                {
-                  "mutability": "Not",
-                  "span": 68,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 69,
-                  "ty": 24
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 26
-                }
-              ],
-              "span": 72,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 68
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 69
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 70
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 71
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 70
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 71
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 4,
           "name": "core::fmt::num::<impl std::fmt::Debug for i32>::fmt"
         }
@@ -1646,83 +1636,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 30
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 30
-                            },
-                            "span": 73,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 73
-                  }
+                          "span": 73,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 73
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 73
                 }
-              ],
-              "span": 73,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 31
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 1
+              }
+            ],
+            "span": 73,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1733,63 +1721,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 73
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 73
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 73
                 }
-              ],
-              "span": 73,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 1
+              }
+            ],
+            "span": 73,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1800,155 +1786,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 73
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 73
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 13,
-                              "kind": "ZeroSized",
-                              "ty": 32
-                            },
-                            "span": 73,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 13,
+                            "kind": "ZeroSized",
+                            "ty": 32
+                          },
+                          "span": 73,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 73
-                  }
+                    }
+                  },
+                  "span": 73
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 73,
-                  "ty": 33
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 73
                 }
-              ],
-              "span": 73,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 73
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 73
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 73
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 33
+              }
+            ],
+            "span": 73,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1959,35 +1943,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 74
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 74
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 74,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 74,
-                  "ty": 34
-                }
-              ],
-              "span": 74,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 74,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 74,
+                "ty": 34
+              }
+            ],
+            "span": 74,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "std::ptr::drop_in_place::<&i32>"
         }
@@ -1998,35 +1980,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 74
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 74
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 74,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 74,
-                  "ty": 31
-                }
-              ],
-              "span": 74,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 74,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 74,
+                "ty": 31
+              }
+            ],
+            "span": 74,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -2037,286 +2017,284 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 77
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 77
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              36
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 77
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 7
-                      },
-                      "span": 78
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 3,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 78
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 8,
-                                  "projection": []
-                                }
-                              },
-                              36
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 78
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 5,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 7,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "StorageLive": 5
+                    },
+                    "span": 77
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 35
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
                             },
-                            "span": 75,
-                            "user_ty": null
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 77
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            36
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 77
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 7
+                    },
+                    "span": 78
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 3,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 78
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 8,
+                                "projection": []
+                              }
+                            },
+                            36
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 78
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
                         },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 76
+                        {
+                          "Move": {
+                            "local": 5,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 7,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 35
+                          },
+                          "span": 75,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 76
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 79,
+                "ty": 37
+              },
+              {
+                "mutability": "Not",
+                "span": 80,
+                "ty": 38
+              },
+              {
+                "mutability": "Not",
+                "span": 81,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 82,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 83,
+                "ty": 39
+              },
+              {
+                "mutability": "Mut",
+                "span": 77,
+                "ty": 36
+              },
+              {
+                "mutability": "Not",
+                "span": 77,
+                "ty": 23
+              },
+              {
+                "mutability": "Mut",
+                "span": 78,
+                "ty": 36
+              },
+              {
+                "mutability": "Not",
+                "span": 78,
+                "ty": 23
+              }
+            ],
+            "span": 84,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "kind",
+                "source_info": {
+                  "scope": 0,
+                  "span": 80
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 79,
-                  "ty": 37
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "left",
+                "source_info": {
+                  "scope": 0,
+                  "span": 81
                 },
-                {
-                  "mutability": "Not",
-                  "span": 80,
-                  "ty": 38
-                },
-                {
-                  "mutability": "Not",
-                  "span": 81,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 82,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 83,
-                  "ty": 39
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 77,
-                  "ty": 36
-                },
-                {
-                  "mutability": "Not",
-                  "span": 77,
-                  "ty": 23
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 78,
-                  "ty": 36
-                },
-                {
-                  "mutability": "Not",
-                  "span": 78,
-                  "ty": 23
-                }
-              ],
-              "span": 84,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "kind",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 80
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "left",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 81
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "right",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 82
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "args",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 83
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "right",
+                "source_info": {
+                  "scope": 0,
+                  "span": 82
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "args",
+                "source_info": {
+                  "scope": 0,
+                  "span": 83
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "core::panicking::assert_failed::<i32, i32>"
         }
@@ -2327,92 +2305,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 15,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 15,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 86,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 86,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 86
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 85
+                        }
+                      ]
+                    },
+                    "span": 86
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 85
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 87,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 87,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 88,
+                "ty": 1
+              }
+            ],
+            "span": 89,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 88
                 },
-                {
-                  "mutability": "Not",
-                  "span": 88,
-                  "ty": 1
-                }
-              ],
-              "span": 89,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 88
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 8,
           "name": "<() as std::process::Termination>::report"
         }
@@ -2423,136 +2399,58 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 18,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 18,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      42,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 16
+                                  }
                                 },
-                                "span": 93,
-                                "user_ty": null
-                              }
+                                "ty": 16
+                              },
+                              "span": 93,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 93
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 90,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 17,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          39,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 91,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 92
-                    }
-                  ],
-                  "terminator": {
+                    "span": 93
+                  },
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 3,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  40
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Constant": {
@@ -2605,538 +2503,614 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 92
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 3,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 3,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                40
+                              ]
                             }
-                          }
-                        ]
+                          ]
+                        }
                       },
-                      "span": 92
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 95
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 96
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              "Tuple",
-                              [
-                                {
-                                  "Move": {
-                                    "local": 5,
-                                    "projection": []
+                            "Constant": {
+                              "const_": {
+                                "id": 16,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      3,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
                                   }
                                 },
-                                {
-                                  "Move": {
-                                    "local": 6,
-                                    "projection": []
+                                "ty": 16
+                              },
+                              "span": 90,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 17,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      39,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
                                   }
+                                },
+                                "ty": 16
+                              },
+                              "span": 91,
+                              "user_ty": null
+                            }
+                          }
+                        ]
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 92
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 3,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
                                 }
                               ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 97
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      25
-                                    ]
-                                  }
-                                ]
-                              }
                             }
                           }
-                        ]
-                      },
-                      "span": 98
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      1,
-                                      25
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 92
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": []
                             }
-                          }
-                        ]
-                      },
-                      "span": 99
+                          ]
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 10,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 7,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
+                    "span": 95
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
                             }
-                          }
-                        ]
-                      },
-                      "span": 100
+                          ]
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 11,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 8,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 101
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
+                    "span": 96
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            "Tuple",
+                            [
                               {
                                 "Move": {
-                                  "local": 10,
+                                  "local": 5,
                                   "projection": []
                                 }
                               },
                               {
                                 "Move": {
-                                  "local": 11,
+                                  "local": 6,
                                   "projection": []
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 94
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 9,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
+                      ]
+                    },
+                    "span": 97
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    25
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    1,
+                                    25
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 99
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 10,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 7,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 100
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 11,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 8,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 101
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 10,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 11,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 94
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 102
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 12,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  10,
-                                  0,
-                                  [],
-                                  null,
-                                  null
-                                ]
-                              },
-                              []
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 9,
+                          "projection": []
+                        }
                       },
-                      "span": 105
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 14,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  11,
-                                  0,
-                                  [
-                                    {
-                                      "Type": 42
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              []
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 106
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 12,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Copy": {
-                              "local": 7,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Copy": {
-                              "local": 8,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 14,
-                              "projection": []
-                            }
-                          }
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
                         ],
-                        "destination": {
-                          "local": 13,
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 94
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 102
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 12,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 19,
-                              "kind": "ZeroSized",
-                              "ty": 41
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                10,
+                                0,
+                                [],
+                                null,
+                                null
+                              ]
                             },
-                            "span": 103,
-                            "user_ty": null
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 105
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 14,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                11,
+                                0,
+                                [
+                                  {
+                                    "Type": 42
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 106
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 12,
+                            "projection": []
                           }
                         },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 104
+                        {
+                          "Copy": {
+                            "local": 7,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Copy": {
+                            "local": 8,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 14,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 13,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 19,
+                            "kind": "ZeroSized",
+                            "ty": 41
+                          },
+                          "span": 103,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 104
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 107,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 108,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 109,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 92,
+                "ty": 43
+              },
+              {
+                "mutability": "Mut",
+                "span": 97,
+                "ty": 44
+              },
+              {
+                "mutability": "Mut",
+                "span": 95,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 96,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 98,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 99,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 94,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 100,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 101,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 110,
+                "ty": 38
+              },
+              {
+                "mutability": "Not",
+                "span": 104,
+                "ty": 37
+              },
+              {
+                "mutability": "Mut",
+                "span": 106,
+                "ty": 39
+              }
+            ],
+            "span": 111,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 108
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 107,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 109
                 },
-                {
-                  "mutability": "Not",
-                  "span": 108,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 109,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 92,
-                  "ty": 43
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 97,
-                  "ty": 44
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 95,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 96,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 98,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 99,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 94,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 100,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 101,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 110,
-                  "ty": 38
-                },
-                {
-                  "mutability": "Not",
-                  "span": 104,
-                  "ty": 37
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 106,
-                  "ty": 39
-                }
-              ],
-              "span": 111,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 108
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 109
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "left_val",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 98
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 7,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "right_val",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 99
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 8,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "kind",
-                  "source_info": {
-                    "scope": 4,
-                    "span": 110
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 12,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "left_val",
+                "source_info": {
+                  "scope": 3,
+                  "span": 98
+                },
+                "value": {
+                  "Place": {
+                    "local": 7,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "right_val",
+                "source_info": {
+                  "scope": 3,
+                  "span": 99
+                },
+                "value": {
+                  "Place": {
+                    "local": 8,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "kind",
+                "source_info": {
+                  "scope": 4,
+                  "span": 110
+                },
+                "value": {
+                  "Place": {
+                    "local": 12,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 9,
           "name": "main"
         }

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -1161,356 +1161,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1521,359 +1519,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1884,177 +1880,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -2065,83 +2059,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -2152,63 +2144,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -2219,155 +2209,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -2378,35 +2366,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -2417,92 +2403,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -2513,60 +2497,20 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 4,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -2581,1706 +2525,1343 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 50
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 4,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 3,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              52,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
+                          ]
                         }
-                      }
-                    },
-                    "span": 51
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "local": 7,
-                            "projection": []
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
                           },
                           {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 7,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Add",
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 10,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 53,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 7,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 6,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              52,
-                              5
-                            ]
-                          ],
-                          "otherwise": 6
-                        }
-                      }
-                    },
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 11,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 55
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 11,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Add",
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 7,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 55
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 11,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 8,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 56,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 10,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 11,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 13,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 13,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Add",
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 8,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 12,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 13,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 10,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 12,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 58
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 9,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              10
-                            ]
-                          ],
-                          "otherwise": 9
-                        }
-                      }
-                    },
-                    "span": 58
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 16,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 59
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 16,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Sub",
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 11,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 59
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 12,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          2
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 14,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 60,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 60
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 15,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 16,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 59
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 15,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              32,
-                              12
-                            ]
-                          ],
-                          "otherwise": 13
-                        }
-                      }
-                    },
-                    "span": 61
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 19,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 62
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 19,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Sub",
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 14,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 62
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 13,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          3
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 17,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 63,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 63
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 18,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 19,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 62
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 18,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              4294967264,
-                              15
-                            ]
-                          ],
-                          "otherwise": 16
-                        }
-                      }
-                    },
-                    "span": 64
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 23,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 65
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 23,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Sub",
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 17,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 65
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 14,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      30,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          4
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 20,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 66,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 66
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 22,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 23,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 65
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 25,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 67
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 25,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Sub",
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 18,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 67
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 24,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 25,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 67
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 21,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Ne",
-                              {
-                                "Move": {
-                                  "local": 22,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 24,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 68
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 21,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              20
-                            ]
-                          ],
-                          "otherwise": 19
-                        }
-                      }
-                    },
-                    "span": 68
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 28,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Mul",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 69
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 28,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Mul",
-                            {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
-                            }
-                          ]
-                        },
-                        "target": 21,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 69
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 15,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          5
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 26,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 70,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 70
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 27,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 28,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 69
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 27,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              420,
-                              22
-                            ]
-                          ],
-                          "otherwise": 23
-                        }
-                      }
-                    },
-                    "span": 71
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 32,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 72,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 72
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 32,
-                            "projection": []
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "OverflowNeg": {
                             "Copy": {
                               "local": 2,
                               "projection": []
                             }
                           }
-                        },
-                        "target": 24,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 72
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                        ]
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 17,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      30,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          6
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 29,
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 50
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            52,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Add",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 7,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 73,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 31,
-                            "projection": []
-                          },
-                          {
-                            "UnaryOp": [
-                              "Neg",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 72
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 33,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Mul",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
+                              "id": 10,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 31,
-                                  "projection": []
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 53,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 7,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
                                 }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 6,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            52,
+                            5
+                          ]
+                        ],
+                        "otherwise": 6
+                      }
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 11,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Add",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
                               }
-                            ]
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 55
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 11,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
                           }
                         ]
                       },
-                      "span": 74
+                      "target": 7,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 33,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
+                  },
+                  "span": 55
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
+                        }
+                      ],
+                      "destination": {
+                        "local": 8,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 56,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 10,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 11,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 13,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Add",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 57
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 13,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 8,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 12,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 13,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 10,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 12,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 58
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 9,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            10
+                          ]
+                        ],
+                        "otherwise": 9
+                      }
+                    }
+                  },
+                  "span": 58
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 16,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Sub",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 59
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 16,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 11,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 59
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 12,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        2
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 14,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 60,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 60
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 15,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 16,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 59
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 15,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            32,
+                            12
+                          ]
+                        ],
+                        "otherwise": 13
+                      }
+                    }
+                  },
+                  "span": 61
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 19,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Sub",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 62
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 19,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 14,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 13,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        3
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 17,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 63,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 63
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 18,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 19,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 62
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 18,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            4294967264,
+                            15
+                          ]
+                        ],
+                        "otherwise": 16
+                      }
+                    }
+                  },
+                  "span": 64
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 23,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Sub",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 65
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 23,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 17,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 65
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 14,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    30,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        4
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 20,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 66,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 66
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 22,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 23,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 65
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 25,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Sub",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 67
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 25,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 18,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 67
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 24,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 25,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 67
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 21,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Ne",
+                            {
+                              "Move": {
+                                "local": 22,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 24,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 68
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 21,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            20
+                          ]
+                        ],
+                        "otherwise": 19
+                      }
+                    }
+                  },
+                  "span": 68
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 28,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Mul",
                             {
                               "Copy": {
@@ -4289,293 +3870,656 @@
                               }
                             },
                             {
-                              "Move": {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 69
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 28,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Mul",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 21,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 69
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        5
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 26,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 70,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 70
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 27,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 28,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 69
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 27,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            420,
+                            22
+                          ]
+                        ],
+                        "otherwise": 23
+                      }
+                    }
+                  },
+                  "span": 71
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 32,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 16,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 72,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 72
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 32,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "OverflowNeg": {
+                          "Copy": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      },
+                      "target": 24,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 72
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 17,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    30,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        6
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 29,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 73,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 73
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 31,
+                          "projection": []
+                        },
+                        {
+                          "UnaryOp": [
+                            "Neg",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 72
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 33,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Mul",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
                                 "local": 31,
                                 "projection": []
                               }
                             }
                           ]
-                        },
-                        "target": 25,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 74
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 30,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 33,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 33,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
-                      },
-                      "span": 74
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 30,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              4294966876,
-                              26
-                            ]
-                          ],
-                          "otherwise": 27
+                          ]
                         }
-                      }
-                    },
-                    "span": 75
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 37,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 76,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
                       },
-                      "span": 76
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 37,
-                            "projection": []
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "OverflowNeg": {
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Mul",
+                          {
                             "Copy": {
                               "local": 1,
                               "projection": []
                             }
+                          },
+                          {
+                            "Move": {
+                              "local": 31,
+                              "projection": []
+                            }
                           }
+                        ]
+                      },
+                      "target": 25,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 74
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 30,
+                          "projection": []
                         },
-                        "target": 28,
-                        "unwind": "Continue"
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 33,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 74
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 30,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            4294966876,
+                            26
+                          ]
+                        ],
+                        "otherwise": 27
                       }
+                    }
+                  },
+                  "span": 75
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 37,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 16,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 76,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 76
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 18,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          7
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 34,
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 37,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "OverflowNeg": {
+                          "Copy": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        }
+                      },
+                      "target": 28,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 76
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 77,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 77
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 36,
-                            "projection": []
-                          },
-                          {
-                            "UnaryOp": [
-                              "Neg",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 76
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 38,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Mul",
-                              {
-                                "Copy": {
-                                  "local": 36,
-                                  "projection": []
+                              "id": 18,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        7
+                                      ]
+                                    ]
+                                  }
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 34,
+                        "projection": []
                       },
-                      "span": 78
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 77,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 77
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 38,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 36,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "UnaryOp": [
+                            "Neg",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 76
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 38,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Mul",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 36,
                                 "projection": []
                               }
@@ -4587,1537 +4531,1718 @@
                               }
                             }
                           ]
-                        },
-                        "target": 29,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 78
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 35,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 38,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 38,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
-                      },
-                      "span": 78
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 35,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              4294966876,
-                              30
-                            ]
-                          ],
-                          "otherwise": 31
+                          ]
                         }
-                      }
-                    },
-                    "span": 79
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 42,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 80,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
                       },
-                      "span": 80
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 42,
-                            "projection": []
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "OverflowNeg": {
-                            "Copy": {
-                              "local": 1,
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Mul",
+                          {
+                            "Move": {
+                              "local": 36,
                               "projection": []
                             }
-                          }
-                        },
-                        "target": 32,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 80
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 19,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          8
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 39,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 81,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 81
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 41,
-                            "projection": []
                           },
                           {
-                            "UnaryOp": [
-                              "Neg",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 80
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 44,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 82,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 82
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 44,
-                            "projection": []
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "OverflowNeg": {
                             "Copy": {
                               "local": 2,
                               "projection": []
                             }
                           }
+                        ]
+                      },
+                      "target": 29,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 78
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 35,
+                          "projection": []
                         },
-                        "target": 33,
-                        "unwind": "Continue"
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 38,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 78
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 35,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            4294966876,
+                            30
+                          ]
+                        ],
+                        "otherwise": 31
                       }
+                    }
+                  },
+                  "span": 79
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 42,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 16,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 80,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 80
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 42,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "OverflowNeg": {
+                          "Copy": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        }
+                      },
+                      "target": 32,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 80
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 19,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        8
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 39,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 81,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 81
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 41,
+                          "projection": []
+                        },
+                        {
+                          "UnaryOp": [
+                            "Neg",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 80
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 44,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 16,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 82,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 82
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 43,
-                            "projection": []
-                          },
-                          {
-                            "UnaryOp": [
-                              "Neg",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 44,
+                          "projection": []
+                        }
                       },
-                      "span": 82
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 45,
+                      "expected": false,
+                      "msg": {
+                        "OverflowNeg": {
+                          "Copy": {
+                            "local": 2,
                             "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Mul",
-                              {
-                                "Copy": {
-                                  "local": 41,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 43,
-                                  "projection": []
-                                }
-                              }
-                            ]
                           }
-                        ]
+                        }
                       },
-                      "span": 83
+                      "target": 33,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 82
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 45,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 43,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "UnaryOp": [
+                            "Neg",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 82
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 45,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Mul",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 41,
                                 "projection": []
                               }
                             },
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 43,
                                 "projection": []
                               }
                             }
                           ]
-                        },
-                        "target": 34,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 83
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 45,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Mul",
                           {
-                            "local": 40,
-                            "projection": []
+                            "Move": {
+                              "local": 41,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 45,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                            "Move": {
+                              "local": 43,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 34,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 83
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 40,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 45,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 83
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 40,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            420,
+                            35
+                          ]
+                        ],
+                        "otherwise": 36
+                      }
+                    }
+                  },
+                  "span": 84
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 47,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitXor",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 86,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 21,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        2,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 87,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 88
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 47,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            3,
+                            37
+                          ]
+                        ],
+                        "otherwise": 38
+                      }
+                    }
+                  },
+                  "span": 85
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 22,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        9
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 83
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 40,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              420,
-                              35
-                            ]
-                          ],
-                          "otherwise": 36
-                        }
-                      }
-                    },
-                    "span": 84
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 47,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitXor",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 86,
-                                  "user_ty": null
                                 }
                               },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 21,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 87,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
-                      },
-                      "span": 88
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 47,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              3,
-                              37
-                            ]
-                          ],
-                          "otherwise": 38
                         }
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                      ],
+                      "destination": {
+                        "local": 46,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 89,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 89
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 49,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitXor",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 91,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 23,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        3,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 92,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 93
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 49,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            2,
+                            39
+                          ]
+                        ],
+                        "otherwise": 40
+                      }
+                    }
+                  },
+                  "span": 90
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 24,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        10
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 48,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 94,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 94
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 51,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitOr",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 96,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 21,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        2,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 97,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 98
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 51,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            3,
+                            41
+                          ]
+                        ],
+                        "otherwise": 42
+                      }
+                    }
+                  },
+                  "span": 95
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 25,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        11
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 50,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 99,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 99
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 53,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitOr",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 101,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 23,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        3,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 102,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 103
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 53,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            3,
+                            43
+                          ]
+                        ],
+                        "otherwise": 44
+                      }
+                    }
+                  },
+                  "span": 100
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 26,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        12
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 52,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 104,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 104
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 55,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 106,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 21,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        2,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 107,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 108
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 55,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            45
+                          ]
+                        ],
+                        "otherwise": 46
+                      }
+                    }
+                  },
+                  "span": 105
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 27,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        13
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 54,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 109,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 109
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 57,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 111,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 23,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        3,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 112,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 113
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 57,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            1,
+                            47
+                          ]
+                        ],
+                        "otherwise": 48
+                      }
+                    }
+                  },
+                  "span": 110
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 28,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        14
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 56,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 114,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 114
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 60,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 116,
+                                "user_ty": null
+                              }
+                            },
+                            28
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 117
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 61,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 60,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 29,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 28
+                                },
+                                "span": 117,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 117
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 61,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 22,
+                                "id": 21,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      2,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          9
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 115,
                               "user_ty": null
                             }
-                          }
-                        ],
-                        "destination": {
-                          "local": 46,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 89,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 89
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 49,
-                            "projection": []
                           },
-                          {
-                            "BinaryOp": [
-                              "BitXor",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 91,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 23,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 92,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 93
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 49,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              2,
-                              39
-                            ]
-                          ],
-                          "otherwise": 40
-                        }
-                      }
-                    },
-                    "span": 90
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
                           {
                             "Constant": {
                               "const_": {
-                                "id": 24,
+                                "id": 20,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          10
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 116,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 48,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 94,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 94
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 51,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitOr",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 96,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 21,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 97,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
                         ]
                       },
-                      "span": 98
+                      "target": 49,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 51,
-                            "projection": []
+                  },
+                  "span": 117
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 30,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        15
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              3,
-                              41
-                            ]
-                          ],
-                          "otherwise": 42
                         }
-                      }
-                    },
-                    "span": 95
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 25,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          11
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 50,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 99,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 99
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 53,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitOr",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 101,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 23,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 102,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 58,
+                        "projection": []
                       },
-                      "span": 103
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 53,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              3,
-                              43
-                            ]
-                          ],
-                          "otherwise": 44
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 118,
+                          "user_ty": null
                         }
-                      }
-                    },
-                    "span": 100
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 118
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 26,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          12
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 52,
+                      "Assign": [
+                        {
+                          "local": 59,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 104,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 104
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 55,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 106,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 21,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 107,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 108
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 55,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              45
-                            ]
-                          ],
-                          "otherwise": 46
-                        }
-                      }
-                    },
-                    "span": 105
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 27,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          13
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 54,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 109,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 109
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 57,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 111,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 23,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 112,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 113
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 57,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              1,
-                              47
-                            ]
-                          ],
-                          "otherwise": 48
-                        }
-                      }
-                    },
-                    "span": 110
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 28,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          14
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 56,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 114,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 114
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 60,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 116,
-                                  "user_ty": null
-                                }
-                              },
-                              28
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 117
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 61,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 60,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 29,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 28
-                                  },
-                                  "span": 117,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 117
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 61,
-                            "projection": []
-                          }
-                        },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -6170,281 +6295,281 @@
                               }
                             }
                           ]
-                        },
-                        "target": 49,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 117
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 59,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            4,
+                            50
+                          ]
+                        ],
+                        "otherwise": 51
+                      }
+                    }
+                  },
+                  "span": 119
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 64,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 121,
+                                "user_ty": null
+                              }
+                            },
+                            28
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 122
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 65,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 64,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 29,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 28
+                                },
+                                "span": 122,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 122
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 65,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shr",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 30,
+                                "id": 21,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      2,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          15
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 120,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 20,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 121,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 58,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 52,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 122
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 31,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        16
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 118,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 118
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 59,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 21,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 115,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 116,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 117
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 59,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              4,
-                              50
-                            ]
-                          ],
-                          "otherwise": 51
                         }
-                      }
-                    },
-                    "span": 119
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 64,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 121,
-                                  "user_ty": null
-                                }
-                              },
-                              28
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 62,
+                        "projection": []
                       },
-                      "span": 122
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 65,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 64,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 29,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 28
-                                  },
-                                  "span": 122,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 123,
+                          "user_ty": null
+                        }
                       },
-                      "span": 122
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 123
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 65,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 63,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shr",
                             {
                               "Constant": {
@@ -6497,281 +6622,281 @@
                               }
                             }
                           ]
-                        },
-                        "target": 52,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 122
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 63,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            1,
+                            53
+                          ]
+                        ],
+                        "otherwise": 54
+                      }
+                    }
+                  },
+                  "span": 124
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 68,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 126,
+                                "user_ty": null
+                              }
+                            },
+                            28
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 127
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 69,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 68,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 29,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 28
+                                },
+                                "span": 127,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 127
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 69,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shr",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 31,
+                                "id": 23,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      3,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          16
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 125,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 20,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 126,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 62,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 55,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 127
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 32,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        17
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 123,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 123
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 63,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shr",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 21,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 120,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 121,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 122
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 63,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              1,
-                              53
-                            ]
-                          ],
-                          "otherwise": 54
                         }
-                      }
-                    },
-                    "span": 124
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 68,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 126,
-                                  "user_ty": null
-                                }
-                              },
-                              28
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 66,
+                        "projection": []
                       },
-                      "span": 127
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 69,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 68,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 29,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 28
-                                  },
-                                  "span": 127,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 128,
+                          "user_ty": null
+                        }
                       },
-                      "span": 127
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 128
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 69,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 67,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shr",
                             {
                               "Constant": {
@@ -6824,281 +6949,281 @@
                               }
                             }
                           ]
-                        },
-                        "target": 55,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 127
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 67,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            1,
+                            56
+                          ]
+                        ],
+                        "otherwise": 57
+                      }
+                    }
+                  },
+                  "span": 129
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 72,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 131,
+                                "user_ty": null
+                              }
+                            },
+                            28
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 132
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 73,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 72,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 29,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 28
+                                },
+                                "span": 132,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 132
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 73,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shr",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 32,
+                                "id": 20,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          17
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 130,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 20,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 131,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 66,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 58,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 132
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 33,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        18
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 128,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 128
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 67,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shr",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 23,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 125,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 126,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 127
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 67,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              1,
-                              56
-                            ]
-                          ],
-                          "otherwise": 57
                         }
-                      }
-                    },
-                    "span": 129
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 72,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 131,
-                                  "user_ty": null
-                                }
-                              },
-                              28
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 70,
+                        "projection": []
                       },
-                      "span": 132
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 73,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 72,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 29,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 28
-                                  },
-                                  "span": 132,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 133,
+                          "user_ty": null
+                        }
                       },
-                      "span": 132
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 133
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 73,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 71,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shr",
                             {
                               "Constant": {
@@ -7151,227 +7276,46 @@
                               }
                             }
                           ]
-                        },
-                        "target": 58,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 132
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 33,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          18
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 71,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            59
+                          ]
                         ],
-                        "destination": {
-                          "local": 70,
+                        "otherwise": 60
+                      }
+                    }
+                  },
+                  "span": 134
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 77,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 133,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 133
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 71,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shr",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 130,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 131,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 132
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 71,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              59
-                            ]
-                          ],
-                          "otherwise": 60
-                        }
-                      }
-                    },
-                    "span": 134
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 77,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 135
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 77,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -7386,215 +7330,215 @@
                               }
                             }
                           ]
-                        },
-                        "target": 61,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 135
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 77,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 34,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          19
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 74,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 61,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 135
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 136,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 136
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 76,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 77,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 34,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        19
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 135
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 75,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Move": {
-                                  "local": 76,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
-                      },
-                      "span": 137
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 75,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              63
-                            ]
-                          ],
-                          "otherwise": 62
                         }
-                      }
+                      ],
+                      "destination": {
+                        "local": 74,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 136,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 136
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 76,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 77,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 135
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 75,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 76,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 137
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 81,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 75,
+                          "projection": []
+                        }
                       },
-                      "span": 138
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            63
+                          ]
+                        ],
+                        "otherwise": 62
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 137
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 81,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 81,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -7609,215 +7553,215 @@
                               }
                             }
                           ]
-                        },
-                        "target": 64,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 138
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 81,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 35,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      27,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          20
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 78,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 64,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 138
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 139,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 139
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 80,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 81,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 35,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    27,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        20
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 138
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 79,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Le",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Move": {
-                                  "local": 80,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
-                      },
-                      "span": 140
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 79,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              66
-                            ]
-                          ],
-                          "otherwise": 65
                         }
-                      }
+                      ],
+                      "destination": {
+                        "local": 78,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 139,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 139
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 80,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 81,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 138
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 79,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Le",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 80,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 140
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 86,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 79,
+                          "projection": []
+                        }
                       },
-                      "span": 141
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            66
+                          ]
+                        ],
+                        "otherwise": 65
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 140
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 86,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 86,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -7832,164 +7776,164 @@
                               }
                             }
                           ]
-                        },
-                        "target": 67,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 141
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 86,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 36,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          21
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 82,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 67,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 141
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 142,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 142
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 85,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 86,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 36,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        21
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 141
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 87,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 85,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 82,
+                        "projection": []
                       },
-                      "span": 143
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 142,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 142
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 87,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 85,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 86,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 141
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 87,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 85,
                                 "projection": []
                               }
@@ -8001,144 +7945,144 @@
                               }
                             }
                           ]
-                        },
-                        "target": 68,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 143
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 87,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 84,
-                            "projection": []
+                            "Move": {
+                              "local": 85,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 87,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
                         ]
                       },
-                      "span": 143
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 83,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Le",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 84,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 144
+                      "target": 68,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 143
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 83,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 84,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              70
-                            ]
-                          ],
-                          "otherwise": 69
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 87,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
                         }
-                      }
+                      ]
+                    },
+                    "span": 143
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 83,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Le",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 84,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 144
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 91,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 83,
+                          "projection": []
+                        }
                       },
-                      "span": 145
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            70
+                          ]
+                        ],
+                        "otherwise": 69
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 144
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 91,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 91,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -8153,215 +8097,215 @@
                               }
                             }
                           ]
-                        },
-                        "target": 71,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 145
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 91,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 37,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          22
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 88,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 71,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 145
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 146,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 146
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 90,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 91,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 37,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        22
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 145
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 89,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Gt",
-                              {
-                                "Move": {
-                                  "local": 90,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
-                      },
-                      "span": 147
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 89,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              73
-                            ]
-                          ],
-                          "otherwise": 72
                         }
-                      }
+                      ],
+                      "destination": {
+                        "local": 88,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 146,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 146
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 90,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 91,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 145
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 89,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Gt",
+                            {
+                              "Move": {
+                                "local": 90,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 147
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 95,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 89,
+                          "projection": []
+                        }
                       },
-                      "span": 148
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            73
+                          ]
+                        ],
+                        "otherwise": 72
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 147
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 95,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 95,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -8376,215 +8320,215 @@
                               }
                             }
                           ]
-                        },
-                        "target": 74,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 148
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 95,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 38,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      27,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          23
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 92,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 74,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 148
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 149,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 149
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 94,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 95,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 38,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    27,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        23
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 148
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 93,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Ge",
-                              {
-                                "Move": {
-                                  "local": 94,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
-                      },
-                      "span": 150
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 93,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              76
-                            ]
-                          ],
-                          "otherwise": 75
                         }
-                      }
+                      ],
+                      "destination": {
+                        "local": 92,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 149,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 149
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 94,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 95,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 148
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 93,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Ge",
+                            {
+                              "Move": {
+                                "local": 94,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 150
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 100,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 93,
+                          "projection": []
+                        }
                       },
-                      "span": 151
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            76
+                          ]
+                        ],
+                        "otherwise": 75
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 150
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 100,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 100,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -8599,164 +8543,164 @@
                               }
                             }
                           ]
-                        },
-                        "target": 77,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 151
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 100,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "Constant": {
-                              "const_": {
-                                "id": 39,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      28,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          24
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 96,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 77,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 151
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
-                            },
-                            "span": 152,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 152
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 99,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 100,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
+                              "id": 39,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    28,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        24
+                                      ]
                                     ]
                                   }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 151
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 101,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 99,
-                                  "projection": []
                                 }
                               },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 96,
+                        "projection": []
                       },
-                      "span": 153
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 152,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 152
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 101,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 99,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 100,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 151
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 101,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 99,
                                 "projection": []
                               }
@@ -8768,726 +8712,764 @@
                               }
                             }
                           ]
-                        },
-                        "target": 78,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 153
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 101,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 98,
-                            "projection": []
+                            "Move": {
+                              "local": 99,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 101,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
                             }
                           }
                         ]
                       },
-                      "span": 153
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 97,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Ge",
-                              {
-                                "Move": {
-                                  "local": 98,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 154
+                      "target": 78,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 153
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 97,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 98,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              80
-                            ]
-                          ],
-                          "otherwise": 79
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 101,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
                         }
-                      }
+                      ]
+                    },
+                    "span": 153
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 97,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Ge",
+                            {
+                              "Move": {
+                                "local": 98,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 154
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 155
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 40,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          25
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 102,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 97,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            80
+                          ]
+                        ],
+                        "otherwise": 79
+                      }
+                    }
+                  },
+                  "span": 154
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 155
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 40,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        25
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 156,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 156
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 157,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 158,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 159,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 63,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 62,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 62,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 68,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 70,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 69,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 69,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 74,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 74,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 77,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 78,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 76,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 76,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 78,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 81,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 83,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 80,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 80,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 82,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 82,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 83,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 89,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 88,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 94,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 93,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 99,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 98,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 104,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 103,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 109,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 108,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 114,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 113,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 118,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 117,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 117,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 117,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 123,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 122,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 122,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 122,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 128,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 127,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 127,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 127,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 133,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 132,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 132,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 132,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 136,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 137,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 135,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 135,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 139,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 140,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 138,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 138,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 142,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 144,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 143,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 141,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 141,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 143,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 146,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 147,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 145,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 145,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 149,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 150,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 148,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 148,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 152,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 154,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 153,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 151,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 151,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 153,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 156,
-                  "ty": 30
-                }
-              ],
-              "span": 160,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "x",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 158
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 102,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 156,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "y",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 159
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                  "span": 156
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 157,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 158,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 159,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 63,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 62,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 62,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 68,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 70,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 69,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 69,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 74,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 74,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 77,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 78,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 76,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 76,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 78,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 81,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 83,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 80,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 80,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 82,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 82,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 83,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 89,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 88,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 94,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 93,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 99,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 98,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 104,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 103,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 109,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 108,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 114,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 113,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 118,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 117,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 117,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 117,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 123,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 122,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 122,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 122,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 128,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 127,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 127,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 127,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 133,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 132,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 132,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 132,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 136,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 137,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 135,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 135,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 139,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 140,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 138,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 138,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 142,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 144,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 143,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 141,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 141,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 143,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 146,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 147,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 145,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 145,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 149,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 150,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 148,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 148,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 152,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 154,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 153,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 151,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 151,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 153,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 156,
+                "ty": 30
+              }
+            ],
+            "span": 160,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "x",
+                "source_info": {
+                  "scope": 0,
+                  "span": 158
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "y",
+                "source_info": {
+                  "scope": 0,
+                  "span": 159
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "test_binop"
         }
@@ -9498,232 +9480,230 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 42,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 16
-                                },
-                                "span": 163,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 164
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 43,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        10,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 16
-                                },
-                                "span": 165,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 166
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 1,
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 41,
-                              "kind": "ZeroSized",
-                              "ty": 31
-                            },
-                            "span": 161,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 42,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      42,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 163,
+                              "user_ty": null
+                            }
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 162
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 167
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 168,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 162,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 164,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 166,
-                  "ty": 16
-                }
-              ],
-              "span": 171,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "x",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 169
+                    "span": 164
                   },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 42,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              42,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 43,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      10,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 165,
+                              "user_ty": null
                             }
                           }
-                        },
-                        "ty": 16
-                      },
-                      "span": 163,
-                      "user_ty": null
-                    }
+                        }
+                      ]
+                    },
+                    "span": 166
                   }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "y",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 170
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 43,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              10,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
                           }
                         },
-                        "ty": 16
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
                       },
-                      "span": 165,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 41,
+                            "kind": "ZeroSized",
+                            "ty": 31
+                          },
+                          "span": 161,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 162
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 167
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 168,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 162,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 164,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 166,
+                "ty": 16
+              }
+            ],
+            "span": 171,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "x",
+                "source_info": {
+                  "scope": 1,
+                  "span": 169
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 42,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            42,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 16
+                    },
+                    "span": 163,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "y",
+                "source_info": {
+                  "scope": 2,
+                  "span": 170
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 43,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            10,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 16
+                    },
+                    "span": 165,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -92,210 +92,208 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        97,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 25
-                                },
-                                "span": 51,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              97,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
-                        }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 11,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      26,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      97,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 27
+                                "ty": 25
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 2,
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            97,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 53
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    26,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 54,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 54
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 28
-                }
-              ],
-              "span": 57,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 56
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 9,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              97,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 25
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
                       },
-                      "span": 51,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 54,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 54
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 28
+              }
+            ],
+            "span": 57,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 56
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 9,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            97,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 25
+                    },
+                    "span": 51,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -306,356 +304,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -666,359 +662,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1029,177 +1023,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1210,83 +1202,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1297,63 +1287,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1364,155 +1352,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1523,35 +1509,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1562,92 +1546,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -106,305 +106,303 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 50
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              "Tuple",
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 10,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            20,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 52,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 11,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            22,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 53,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
                             },
-                            "span": 50,
-                            "user_ty": null
-                          }
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 50
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        {
+                          "Aggregate": [
+                            "Tuple",
+                            [
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 10,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          20,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 52,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 11,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          22,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 53,
+                                  "user_ty": null
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
                     },
                     "span": 51
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Move": {
-                            "local": 2,
+                            "local": 3,
                             "projection": []
                           }
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
-                        }
-                      }
-                    },
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 55
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 13,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      35,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 5,
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 50,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 55
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 26
+                              "id": 13,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    35,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
                             },
-                            "span": 56,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 58,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 31
-                }
-              ],
-              "span": 59,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "sum",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 58
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 14,
-                        "kind": "ZeroSized",
-                        "ty": 28
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 56,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 56
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 58,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 31
+              }
+            ],
+            "span": 59,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "sum",
+                "source_info": {
+                  "scope": 1,
+                  "span": 58
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 14,
+                      "kind": "ZeroSized",
+                      "ty": 28
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -415,60 +413,20 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 3,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 60
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 3,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 4,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  32
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -483,112 +441,150 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 60
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 4,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                32
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "local": 0,
-                            "projection": []
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
+                            "Copy": {
+                              "local": 3,
+                              "projection": []
                             }
                           }
                         ]
                       },
-                      "span": 60
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 61
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 62,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 63,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Not",
-                  "span": 64,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 65,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 33
-                }
-              ],
-              "span": 63,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "x",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 64
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                  "span": 60
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 60
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 61
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 62,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 63,
+                "ty": 29
+              },
+              {
+                "mutability": "Not",
+                "span": 64,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 65,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 33
+              }
+            ],
+            "span": 63,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "x",
+                "source_info": {
+                  "scope": 0,
+                  "span": 64
                 },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "y",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 65
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "y",
+                "source_info": {
+                  "scope": 0,
+                  "span": 65
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "main::{closure#0}"
         }
@@ -599,356 +595,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -959,359 +953,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1322,177 +1314,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1503,83 +1493,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1590,63 +1578,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1657,155 +1643,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1816,35 +1800,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1855,92 +1837,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -100,237 +100,235 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
                               "projection": []
                             }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 25
-                            },
-                            "span": 50,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                          ]
+                        }
+                      ]
                     },
-                    "span": 51
+                    "span": 50
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Move": {
-                            "local": 2,
+                            "local": 3,
                             "projection": []
                           }
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
-                        }
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 11,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 27
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 4,
-                          "projection": []
-                        },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 10,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 26
+                              "ty": 1
                             },
-                            "span": 54,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 54
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 56,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 31
-                }
-              ],
-              "span": 57,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "sum",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 56
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 12,
-                        "kind": "ZeroSized",
-                        "ty": 28
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 50,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 53
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 27
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 4,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 26
+                          },
+                          "span": 54,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 54
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 56,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 31
+              }
+            ],
+            "span": 57,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "sum",
+                "source_info": {
+                  "scope": 1,
+                  "span": 56
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 12,
+                      "kind": "ZeroSized",
+                      "ty": 28
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -341,74 +339,72 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 13,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 13,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      42,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 29
+                                  }
                                 },
-                                "span": 59,
-                                "user_ty": null
-                              }
+                                "ty": 29
+                              },
+                              "span": 59,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 59
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 58
+                        }
+                      ]
+                    },
+                    "span": 59
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 58
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 30
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 30
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 7,
           "name": "main::{closure#0}"
         }
@@ -419,356 +415,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -779,359 +773,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1142,177 +1134,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1323,83 +1313,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1410,63 +1398,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1477,155 +1463,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1636,35 +1620,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1675,92 +1657,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -90,171 +90,65 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 10,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 26
-                                },
-                                "span": 58,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 59
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 11,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 26
-                                },
-                                "span": 60,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 61
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 1,
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 56,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
-                        }
-                      }
-                    },
-                    "span": 62
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 13,
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      42,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 58,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 59
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 11,
                                 "kind": {
                                   "Allocated": {
                                     "align": 8,
@@ -266,188 +160,292 @@
                                       0,
                                       0,
                                       0,
-                                      0,
-                                      19,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 29
+                                "ty": 26
                               },
-                              "span": 32,
+                              "span": 60,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 4,
-                          "projection": []
+                        }
+                      ]
+                    },
+                    "span": 61
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         },
-                        "func": {
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 56,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 28
+                              "id": 13,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    19,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 29
                             },
-                            "span": 63,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ],
+                      "destination": {
+                        "local": 4,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 28
+                          },
+                          "span": 63,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 63
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 64
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 66,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 63,
+                "ty": 30
+              }
+            ],
+            "span": 69,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "x",
+                "source_info": {
+                  "scope": 1,
+                  "span": 67
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 10,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            42,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 26
                     },
-                    "span": 63
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 64
+                    "span": 58,
+                    "user_ty": null
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "y",
+                "source_info": {
+                  "scope": 2,
+                  "span": 68
                 },
-                {
-                  "mutability": "Not",
-                  "span": 66,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 63,
-                  "ty": 30
-                }
-              ],
-              "span": 69,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "x",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 67
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 10,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              42,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 11,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
                           }
-                        },
-                        "ty": 26
+                        }
                       },
-                      "span": 58,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "y",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 68
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 11,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 26
-                      },
-                      "span": 60,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "z",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 66
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
+                      "ty": 26
+                    },
+                    "span": 60,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "z",
+                "source_info": {
+                  "scope": 3,
+                  "span": 66
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }
@@ -458,100 +456,98 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Gt",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Gt",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
                               }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 50
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 50
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 53,
+                "ty": 26
+              },
+              {
+                "mutability": "Not",
+                "span": 54,
+                "ty": 26
+              }
+            ],
+            "span": 55,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "x",
+                "source_info": {
+                  "scope": 0,
+                  "span": 53
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 25
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "y",
+                "source_info": {
+                  "scope": 0,
+                  "span": 54
                 },
-                {
-                  "mutability": "Not",
-                  "span": 53,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Not",
-                  "span": 54,
-                  "ty": 26
-                }
-              ],
-              "span": 55,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "x",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 53
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "y",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 54
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "test"
         }
@@ -562,356 +558,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -922,359 +916,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1285,177 +1277,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1466,83 +1456,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1553,63 +1541,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1620,155 +1606,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1779,35 +1763,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1818,92 +1800,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -98,91 +98,299 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        10,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
                                       }
-                                    },
-                                    "ty": 16
+                                    }
                                   },
-                                  "span": 52,
-                                  "user_ty": null
+                                  "ty": 16
+                                },
+                                "span": 52,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 11,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "DivisionByZero": {
+                          "Constant": {
+                            "const_": {
+                              "id": 9,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    164,
+                                    1,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
+                                  }
                                 }
                               },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 11,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
+                              "ty": 16
+                            },
+                            "span": 50,
+                            "user_ty": null
                           }
-                        ]
+                        }
                       },
-                      "span": 51
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "DivisionByZero": {
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        10,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 52,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 12,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        255,
+                                        255,
+                                        255,
+                                        255
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 9,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        164,
+                                        1,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 50,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 13,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 5,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Div",
+                          {
                             "Constant": {
                               "const_": {
                                 "id": 9,
@@ -206,190 +414,52 @@
                               "span": 50,
                               "user_ty": null
                             }
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 51
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
                           },
                           {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 52,
-                                  "user_ty": null
-                                }
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      10,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
                               },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 12,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          255,
-                                          255,
-                                          255,
-                                          255
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
+                              "span": 52,
+                              "user_ty": null
+                            }
                           }
                         ]
                       },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          164,
-                                          1,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 13,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
+                      "target": 2,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 5,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Div",
                             {
                               "Constant": {
@@ -442,227 +512,155 @@
                               }
                             }
                           ]
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 51
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Div",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          164,
-                                          1,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 52,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              3
-                            ]
-                          ],
-                          "otherwise": 4
-                        }
-                      }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 15,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 26
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 6,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            3
+                          ]
+                        ],
+                        "otherwise": 4
+                      }
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 54
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 55,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 55
-                  }
+                        }
+                      ],
+                      "destination": {
+                        "local": 6,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 55
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 28
-                }
-              ],
-              "span": 57,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 28
+              }
+            ],
+            "span": 57,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "main"
         }
@@ -673,356 +671,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1033,359 +1029,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1396,177 +1390,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1577,83 +1569,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1664,63 +1654,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1731,155 +1719,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1890,35 +1876,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1929,92 +1913,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -93,327 +93,325 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 16
-                                },
-                                "span": 51,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 53
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "CopyForDeref": {
-                              "local": 3,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 6,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 4,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
-                        }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 55
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 11,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      27,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      42,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 26
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 5,
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "CopyForDeref": {
+                            "local": 3,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "span": 54
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 6,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 54
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 4,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 55
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    27,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 56,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 56,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 58,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 60,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 27
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 58
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 59
                 },
-                {
-                  "mutability": "Not",
-                  "span": 58,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 60,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 27
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 58
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 59
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "c",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 60
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "c",
+                "source_info": {
+                  "scope": 3,
+                  "span": 60
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -424,356 +422,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -784,359 +780,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1147,177 +1141,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1328,83 +1320,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1415,63 +1405,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1482,155 +1470,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1641,35 +1627,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1680,92 +1664,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -47,356 +47,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -407,359 +405,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -770,177 +766,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -951,83 +945,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1038,63 +1030,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1105,155 +1095,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1264,35 +1252,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1303,77 +1289,75 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  7,
-                                  0,
-                                  [],
-                                  null,
-                                  null
-                                ]
-                              },
-                              []
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 50
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                7,
+                                0,
+                                [],
+                                null,
+                                null
+                              ]
+                            },
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 50
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 1
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 53,
+                "ty": 25
+              }
+            ],
+            "span": 54,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 53
                 },
-                {
-                  "mutability": "Not",
-                  "span": 53,
-                  "ty": 25
-                }
-              ],
-              "span": 54,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 53
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -1384,92 +1368,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -97,356 +97,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -457,359 +455,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -820,177 +816,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1001,83 +995,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1088,63 +1080,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1155,155 +1145,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1314,35 +1302,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1353,92 +1339,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1449,206 +1433,204 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 13,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 4,
-                                    "bytes": [
-                                      5,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": []
-                                    }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 13,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    5,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
                                   }
-                                },
-                                "ty": 26
+                                }
                               },
-                              "span": 68,
-                              "user_ty": null
-                            }
+                              "ty": 26
+                            },
+                            "span": 68,
+                            "user_ty": null
                           }
-                        ],
-                        "destination": {
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 67,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 69
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
                           "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 67,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 69
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              5,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
                         }
-                      }
-                    },
-                    "span": 70
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 71
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 15,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      26,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 30
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            5,
+                            2
+                          ]
                         ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 70
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 71
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 29
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    26,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 30
                             },
-                            "span": 72,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 72
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 74,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 31
-                }
-              ],
-              "span": 75,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ans",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 74
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 72,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 72
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 74,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 31
+              }
+            ],
+            "span": 75,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ans",
+                "source_info": {
+                  "scope": 1,
+                  "span": 74
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }
@@ -1659,108 +1641,49 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ],
-                            [
-                              1,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
                         }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          2,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
                       },
-                      "span": 52
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ],
+                          [
+                            1,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 4,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -1794,245 +1717,245 @@
                               }
                             }
                           ]
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 4,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 0,
-                            "projection": []
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 10,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        1,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      2,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 26
+                                  }
                                 },
-                                "span": 53,
-                                "user_ty": null
-                              }
+                                "ty": 26
+                              },
+                              "span": 51,
+                              "user_ty": null
                             }
                           }
                         ]
                       },
-                      "span": 53
+                      "target": 4,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Goto": {
-                        "target": 9
-                      }
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 53,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
                     },
                     "span": 53
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 11,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 9
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 11,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 26
+                                  }
                                 },
-                                "span": 54,
-                                "user_ty": null
-                              }
+                                "ty": 26
+                              },
+                              "span": 54,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 54
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 9
-                      }
+                        }
+                      ]
                     },
                     "span": 54
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 52
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 9
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 55,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
                           }
-                        },
-                        "target": 5,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 56
+                    "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 57,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 58
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Move": {
-                            "local": 7,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
+                            "local": 3,
+                            "projection": []
                           }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 5,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -2066,262 +1989,319 @@
                               }
                             }
                           ]
-                        },
-                        "target": 6,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 58
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 7,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 7,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
+                          ]
+                        }
                       },
-                      "span": 58
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "Move": {
-                              "local": 6,
+                            "Copy": {
+                              "local": 1,
                               "projection": []
                             }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 59,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 7,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 60
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
                           },
                           {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
                               },
-                              {
-                                "Copy": {
-                                  "local": 5,
-                                  "projection": []
-                                }
-                              }
-                            ]
+                              "span": 57,
+                              "user_ty": null
+                            }
                           }
                         ]
                       },
-                      "span": 61
+                      "target": 6,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 58
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 8,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 7,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 58
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 59,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 7,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 60
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 2,
                                 "projection": []
                               }
                             },
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 5,
                                 "projection": []
                               }
                             }
                           ]
-                        },
-                        "target": 8,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 61
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 8,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "local": 0,
-                            "projection": []
+                            "Move": {
+                              "local": 2,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 8,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                            "Move": {
+                              "local": 5,
+                              "projection": []
                             }
                           }
                         ]
                       },
-                      "span": 61
+                      "target": 8,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 9
-                      }
-                    },
-                    "span": 62
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 63
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 64,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Not",
-                  "span": 65,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 28
-                }
-              ],
-              "span": 66,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 65
                   },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                  "span": 61
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 8,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 61
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 9
                     }
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 63
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 64,
+                "ty": 26
+              },
+              {
+                "mutability": "Not",
+                "span": 65,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 28
+              }
+            ],
+            "span": 66,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 65
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "fibonacci"
         }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -139,356 +139,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -499,359 +497,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -862,177 +858,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1043,83 +1037,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1130,63 +1122,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1197,155 +1187,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1356,35 +1344,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1395,92 +1381,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1491,31 +1475,142 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      96,
+                                      64
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 25
+                              },
+                              "span": 51,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      154,
+                                      153,
+                                      153,
+                                      63
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 25
+                              },
+                              "span": 53,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 54
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Add",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
                               "Constant": {
                                 "const_": {
-                                  "id": 9,
+                                  "id": 11,
                                   "kind": {
                                     "Allocated": {
                                       "align": 4,
                                       "bytes": [
-                                        0,
-                                        0,
-                                        96,
+                                        102,
+                                        102,
+                                        150,
                                         64
                                       ],
                                       "mutability": "Mut",
@@ -1526,177 +1621,185 @@
                                   },
                                   "ty": 25
                                 },
-                                "span": 51,
+                                "span": 56,
                                 "user_ty": null
                               }
                             }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 10,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        154,
-                                        153,
-                                        153,
-                                        63
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 25
-                                },
-                                "span": 53,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Add",
-                              {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 11,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          102,
-                                          102,
-                                          150,
-                                          64
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 56,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
+                          ]
                         }
-                      }
+                      ]
                     },
                     "span": 50
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 12,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      12,
+                                      64
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 58,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 59
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 13,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      51,
+                                      51,
+                                      51,
+                                      51,
+                                      51,
+                                      51,
+                                      243,
+                                      63
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 60,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 61
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Add",
+                            {
+                              "Move": {
+                                "local": 8,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 9,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 62
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            {
                               "Constant": {
                                 "const_": {
-                                  "id": 12,
+                                  "id": 14,
                                   "kind": {
                                     "Allocated": {
                                       "align": 8,
                                       "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        12,
+                                        205,
+                                        204,
+                                        204,
+                                        204,
+                                        204,
+                                        204,
+                                        18,
                                         64
                                       ],
                                       "mutability": "Mut",
@@ -1707,517 +1810,396 @@
                                   },
                                   "ty": 26
                                 },
-                                "span": 58,
+                                "span": 63,
                                 "user_ty": null
                               }
                             }
-                          }
-                        ]
-                      },
-                      "span": 59
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 13,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        51,
-                                        51,
-                                        51,
-                                        51,
-                                        51,
-                                        51,
-                                        243,
-                                        63
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 26
-                                },
-                                "span": 60,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 61
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Add",
-                              {
-                                "Move": {
-                                  "local": 8,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 9,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 62
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 14,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 8,
-                                        "bytes": [
-                                          205,
-                                          204,
-                                          204,
-                                          204,
-                                          204,
-                                          204,
-                                          18,
-                                          64
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 63,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 6,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              4
-                            ]
-                          ],
-                          "otherwise": 3
+                          ]
                         }
-                      }
+                      ]
                     },
                     "span": 57
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 16,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      30,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 28
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 6,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            4
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 15,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 16,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    30,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 64,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 64
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 65
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 17,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      30,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 28
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 10,
-                          "projection": []
-                        },
-                        "func": {
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 15,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 64,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 64
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 65
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 15,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 17,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    30,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 66,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ],
+                      "destination": {
+                        "local": 10,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 15,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 66,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 66
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 64,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 62,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 30
+              }
+            ],
+            "span": 72,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 68
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 9,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            0,
+                            0,
+                            96,
+                            64
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 25
                     },
-                    "span": 66
+                    "span": 51,
+                    "user_ty": null
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 69
                 },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 64,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 62,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 30
-                }
-              ],
-              "span": 72,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 68
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 9,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              0,
-                              0,
-                              96,
-                              64
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 10,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            154,
+                            153,
+                            153,
+                            63
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
                           }
-                        },
-                        "ty": 25
+                        }
                       },
-                      "span": 51,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 69
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 10,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              154,
-                              153,
-                              153,
-                              63
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 25
-                      },
-                      "span": 53,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "c",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 70
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 12,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              12,
-                              64
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 26
-                      },
-                      "span": 58,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "d",
-                  "source_info": {
-                    "scope": 4,
-                    "span": 71
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 13,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              51,
-                              51,
-                              51,
-                              51,
-                              51,
-                              51,
-                              243,
-                              63
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 26
-                      },
-                      "span": 60,
-                      "user_ty": null
-                    }
+                      "ty": 25
+                    },
+                    "span": 53,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "c",
+                "source_info": {
+                  "scope": 3,
+                  "span": 70
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 12,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            12,
+                            64
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 26
+                    },
+                    "span": 58,
+                    "user_ty": null
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "d",
+                "source_info": {
+                  "scope": 4,
+                  "span": 71
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 13,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            51,
+                            51,
+                            51,
+                            51,
+                            51,
+                            51,
+                            243,
+                            63
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 26
+                    },
+                    "span": 60,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -96,356 +96,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -456,359 +454,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -819,177 +815,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1000,83 +994,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1087,63 +1079,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1154,155 +1144,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1313,35 +1301,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1352,92 +1338,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1448,91 +1432,299 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        10,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
                                       }
-                                    },
-                                    "ty": 16
+                                    }
                                   },
-                                  "span": 52,
-                                  "user_ty": null
+                                  "ty": 16
+                                },
+                                "span": 52,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 11,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "RemainderByZero": {
+                          "Constant": {
+                            "const_": {
+                              "id": 9,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    42,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
+                                  }
                                 }
                               },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 11,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
+                              "ty": 16
+                            },
+                            "span": 50,
+                            "user_ty": null
                           }
-                        ]
+                        }
                       },
-                      "span": 51
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "RemainderByZero": {
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        10,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 52,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 12,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        255,
+                                        255,
+                                        255,
+                                        255
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 9,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        42,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 50,
+                                "user_ty": null
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 13,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        0,
+                                        0,
+                                        0,
+                                        128
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "BitAnd",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 51
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 5,
+                          "projection": []
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Rem",
+                          {
                             "Constant": {
                               "const_": {
                                 "id": 9,
@@ -1556,190 +1748,52 @@
                               "span": 50,
                               "user_ty": null
                             }
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 51
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
                           },
                           {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 52,
-                                  "user_ty": null
-                                }
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      10,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
                               },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 12,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          255,
-                                          255,
-                                          255,
-                                          255
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
+                              "span": 52,
+                              "user_ty": null
+                            }
                           }
                         ]
                       },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          42,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 13,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "BitAnd",
-                              {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
+                      "target": 2,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 5,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Rem",
                             {
                               "Constant": {
@@ -1792,227 +1846,155 @@
                               }
                             }
                           ]
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 51
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Rem",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          42,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          10,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 52,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              2,
-                              3
-                            ]
-                          ],
-                          "otherwise": 4
-                        }
-                      }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 15,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      30,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 26
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 6,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            2,
+                            3
+                          ]
+                        ],
+                        "otherwise": 4
+                      }
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 54
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    30,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 55,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 55
-                  }
+                        }
+                      ],
+                      "destination": {
+                        "local": 6,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 55
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 28
-                }
-              ],
-              "span": 57,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 28
+              }
+            ],
+            "span": 57,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "main"
         }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -105,206 +105,204 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 14,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 4,
-                                    "bytes": [
-                                      10,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": []
-                                    }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 14,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    10,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
                                   }
-                                },
-                                "ty": 26
+                                }
                               },
-                              "span": 73,
-                              "user_ty": null
-                            }
+                              "ty": 26
+                            },
+                            "span": 73,
+                            "user_ty": null
                           }
-                        ],
-                        "destination": {
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 13,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 72,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 74
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
                           "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 13,
-                              "kind": "ZeroSized",
-                              "ty": 29
-                            },
-                            "span": 72,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 74
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
                         }
-                      }
-                    },
-                    "span": 75
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 76
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 16,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 31
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
                         ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 75
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 76
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 15,
-                              "kind": "ZeroSized",
-                              "ty": 30
+                              "id": 16,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 31
                             },
-                            "span": 77,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 77
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 78,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 79,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 77,
-                  "ty": 32
-                }
-              ],
-              "span": 80,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ans",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 79
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 15,
+                            "kind": "ZeroSized",
+                            "ty": 30
+                          },
+                          "span": 77,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 77
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 78,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 79,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 77,
+                "ty": 32
+              }
+            ],
+            "span": 80,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ans",
+                "source_info": {
+                  "scope": 1,
+                  "span": 79
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 8,
           "name": "main"
         }
@@ -315,151 +313,92 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
                         }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
                       }
-                    },
-                    "span": 61
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 12,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                    }
+                  },
+                  "span": 61
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 12,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 25
+                                  }
                                 },
-                                "span": 63,
-                                "user_ty": null
-                              }
+                                "ty": 25
+                              },
+                              "span": 63,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 63
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 4
-                      }
+                        }
+                      ]
                     },
-                    "span": 62
+                    "span": 63
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 64,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 65
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 4
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 3,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -493,127 +432,184 @@
                               }
                             }
                           ]
-                        },
-                        "target": 3,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 65
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 3,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 2,
-                            "projection": []
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 3,
-                                "projection": [
-                                  {
-                                    "Field": [
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
-                                      26
-                                    ]
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
                                   }
-                                ]
-                              }
+                                },
+                                "ty": 26
+                              },
+                              "span": 64,
+                              "user_ty": null
                             }
                           }
                         ]
                       },
-                      "span": 65
+                      "target": 3,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 65
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 13,
-                              "kind": "ZeroSized",
-                              "ty": 29
-                            },
-                            "span": 66,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 3,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
                           }
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 67
+                    "span": 65
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 68
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 69,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 70,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 28
-                }
-              ],
-              "span": 71,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 70
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 13,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 66,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 67
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 68
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 69,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 70,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 28
+              }
+            ],
+            "span": 71,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 70
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 7,
           "name": "is_odd"
         }
@@ -624,151 +620,92 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
                         }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
                       }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        1
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      1
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 25
+                                  }
                                 },
-                                "span": 52,
-                                "user_ty": null
-                              }
+                                "ty": 25
+                              },
+                              "span": 52,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 4
-                      }
+                        }
+                      ]
                     },
-                    "span": 51
+                    "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 53,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 54
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 4
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 3,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -802,127 +739,184 @@
                               }
                             }
                           ]
-                        },
-                        "target": 3,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 54
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 3,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 2,
-                            "projection": []
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 3,
-                                "projection": [
-                                  {
-                                    "Field": [
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
-                                      26
-                                    ]
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
                                   }
-                                ]
-                              }
+                                },
+                                "ty": 26
+                              },
+                              "span": 53,
+                              "user_ty": null
                             }
                           }
                         ]
                       },
-                      "span": 54
+                      "target": 3,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 55,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 3,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
                           }
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 56
+                    "span": 54
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 57
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 28
-                }
-              ],
-              "span": 60,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 59
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 57
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 28
+              }
+            ],
+            "span": 60,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 59
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "is_even"
         }
@@ -933,356 +927,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1293,359 +1285,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1656,177 +1646,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1837,83 +1825,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1924,63 +1910,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1991,155 +1975,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -2150,35 +2132,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -2189,92 +2169,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -57,211 +57,209 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  8,
-                                  1,
-                                  [
-                                    {
-                                      "Type": 26
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 11,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            42,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 26
-                                    },
-                                    "span": 62,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 63
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  8,
-                                  0,
-                                  [
-                                    {
-                                      "Type": 26
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              []
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 64
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Copy": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
+                      "Assign": [
+                        {
+                          "local": 1,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 29
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                8,
+                                1,
+                                [
+                                  {
+                                    "Type": 26
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
                             },
-                            "span": 60,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                            [
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 11,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          42,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 26
+                                  },
+                                  "span": 62,
+                                  "user_ty": null
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
                     },
-                    "span": 61
+                    "span": 63
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                8,
+                                0,
+                                [
+                                  {
+                                    "Type": 26
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 64
                   }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Copy": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 60,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 61
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 65
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 67,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 68,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 69,
+                "ty": 26
+              }
+            ],
+            "span": 70,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 67
                 },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 65
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 68
                 },
-                {
-                  "mutability": "Not",
-                  "span": 67,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 68,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 69,
-                  "ty": 26
-                }
-              ],
-              "span": 70,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 67
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 68
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "c",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 69
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "c",
+                "source_info": {
+                  "scope": 3,
+                  "span": 69
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }
@@ -272,356 +270,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -632,359 +628,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -995,177 +989,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1176,83 +1168,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1263,63 +1253,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1330,155 +1318,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1489,35 +1475,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1528,188 +1512,186 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Discriminant": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ],
-                            [
-                              1,
-                              3
-                            ]
-                          ],
-                          "otherwise": 1
-                        }
-                      }
-                    },
-                    "span": 45
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Unreachable",
-                    "span": 46
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 3,
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 8,
-                              "kind": "ZeroSized",
-                              "ty": 25
-                            },
-                            "span": 47,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 48
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
+                        {
+                          "Discriminant": {
+                            "local": 1,
                             "projection": []
+                          }
+                        }
+                      ]
+                    },
+                    "span": 46
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ],
+                          [
+                            1,
+                            3
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
+                    }
+                  },
+                  "span": 45
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Unreachable",
+                  "span": 46
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 8,
+                            "kind": "ZeroSized",
+                            "ty": 25
                           },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Downcast": 1
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                          "span": 47,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 48
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Downcast": 1
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 49
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 48,
-                  "ty": 28
-                }
-              ],
-              "span": 54,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 52
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "val",
-                  "source_info": {
-                    "scope": 1,
+                        }
+                      ]
+                    },
                     "span": 50
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 49
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 26
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 6
+              },
+              {
+                "mutability": "Mut",
+                "span": 48,
+                "ty": 28
+              }
+            ],
+            "span": 54,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 52
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "val",
+                "source_info": {
+                  "scope": 1,
+                  "span": 50
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 5,
           "name": "std::option::Option::<u32>::unwrap"
         }
@@ -1720,92 +1702,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 56,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 56,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 55
+                        }
+                      ]
+                    },
+                    "span": 56
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 55
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 58,
+                "ty": 1
+              }
+            ],
+            "span": 59,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 58
                 },
-                {
-                  "mutability": "Not",
-                  "span": 58,
-                  "ty": 1
-                }
-              ],
-              "span": 59,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 58
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -90,98 +90,20 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          254,
-                                          255,
-                                          255,
-                                          255
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 2,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Constant": {
@@ -234,298 +156,374 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 2,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 11,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        255,
-                                        255,
-                                        255,
-                                        255
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 26
-                                },
-                                "span": 54,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 53
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 3,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 13,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      24,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      254,
+                                      255,
+                                      255,
+                                      255
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 50,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 28
+                                "ty": 26
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 5,
+                        ]
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 57,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 30
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 60
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 11,
-                        "kind": {
-                          "Allocated": {
-                            "align": 4,
-                            "bytes": [
-                              255,
-                              255,
-                              255,
-                              255
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        },
-                        "ty": 26
-                      },
-                      "span": 54,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 59
+                        }
+                      ]
+                    },
+                    "span": 52
                   },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 11,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      255,
+                                      255,
+                                      255,
+                                      255
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 54,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 53
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
                     }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 13,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    24,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 57,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 30
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 60
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 11,
+                      "kind": {
+                        "Allocated": {
+                          "align": 4,
+                          "bytes": [
+                            255,
+                            255,
+                            255,
+                            255
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 26
+                    },
+                    "span": 54,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 59
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -536,356 +534,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -896,359 +892,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1259,177 +1253,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1440,83 +1432,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1527,63 +1517,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1594,155 +1582,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1753,35 +1739,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1792,92 +1776,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -98,104 +98,45 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
                         }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
                       },
-                      "span": 52
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 4,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -229,326 +170,47 @@
                               }
                             }
                           ]
-                        },
-                        "target": 3,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 10,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 26
-                                },
-                                "span": 53,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 53
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 6
-                      }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 54,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 55
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 5,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Add",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 4,
+                          "projection": [
                             {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Move": {
-                                "local": 2,
-                                "projection": []
-                              }
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
                           ]
-                        },
-                        "target": 5,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 5,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
+                        }
                       },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 6
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 58
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Not",
-                  "span": 60,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 28
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 60
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 6,
-          "name": "sum_to_n_rec"
-        }
-      },
-      "symbol_name": "_ZN22recursion_simple_match12sum_to_n_rec17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
                           {
                             "Constant": {
                               "const_": {
-                                "id": 12,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
                                     "align": 4,
                                     "bytes": [
-                                      10,
+                                      1,
                                       0,
                                       0,
                                       0
@@ -561,91 +223,37 @@
                                 },
                                 "ty": 26
                               },
-                              "span": 63,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 1,
+                        ]
+                      },
+                      "target": 3,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 62,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 64
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              55,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
-                        }
-                      }
-                    },
-                    "span": 65
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 66
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 14,
+                                "id": 10,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      27,
-                                      0,
-                                      0,
-                                      0,
                                       0,
                                       0,
                                       0,
@@ -653,83 +261,471 @@
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 30
+                                "ty": 26
                               },
-                              "span": 32,
+                              "span": 53,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 2,
+                        }
+                      ]
+                    },
+                    "span": 53
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 6
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 54,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 55
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
+                            "Add",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 5,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Move": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 5,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 56
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 6
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 58
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 26
+              },
+              {
+                "mutability": "Not",
+                "span": 60,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 28
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 60
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 6,
+          "name": "sum_to_n_rec"
+        }
+      },
+      "symbol_name": "_ZN22recursion_simple_match12sum_to_n_rec17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 13,
-                              "kind": "ZeroSized",
-                              "ty": 29
+                              "id": 12,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    10,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 67,
+                            "span": 63,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 67
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 68,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 69,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 31
-                }
-              ],
-              "span": 70,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ans",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 69
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 62,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 64
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            55,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 65
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 66
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 14,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    27,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 30
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 13,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 67,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 67
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 68,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 69,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 31
+              }
+            ],
+            "span": 70,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ans",
+                "source_info": {
+                  "scope": 1,
+                  "span": 69
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }
@@ -740,356 +736,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1100,359 +1094,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1463,177 +1455,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1644,83 +1634,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1731,63 +1719,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1798,155 +1784,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1957,35 +1941,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1996,92 +1978,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -98,154 +98,95 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
                         }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
                       }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 25
+                                  }
                                 },
-                                "span": 52,
-                                "user_ty": null
-                              }
+                                "ty": 25
+                              },
+                              "span": 52,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 6
-                      }
+                        }
+                      ]
                     },
-                    "span": 51
+                    "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 53,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 54
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 6
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 4,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  26
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
                               "Copy": {
@@ -279,276 +220,47 @@
                               }
                             }
                           ]
-                        },
-                        "target": 3,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 54
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 4,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      25
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 55,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 5,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  26
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
-                            "Add",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 4,
+                          "projection": [
                             {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            },
-                            {
-                              "Move": {
-                                "local": 2,
-                                "projection": []
-                              }
+                              "Field": [
+                                1,
+                                26
+                              ]
                             }
                           ]
-                        },
-                        "target": 5,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 5,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      25
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
+                        }
                       },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 6
-                      }
-                    },
-                    "span": 51
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 58
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Not",
-                  "span": 60,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 28
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 60
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 6,
-          "name": "sum_to_n_rec"
-        }
-      },
-      "symbol_name": "_ZN16recursion_simple12sum_to_n_rec17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
                           {
                             "Constant": {
                               "const_": {
-                                "id": 12,
+                                "id": 10,
                                 "kind": {
                                   "Allocated": {
                                     "align": 4,
                                     "bytes": [
-                                      10,
+                                      1,
                                       0,
                                       0,
                                       0
@@ -561,175 +273,459 @@
                                 },
                                 "ty": 25
                               },
-                              "span": 63,
+                              "span": 53,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 1,
+                        ]
+                      },
+                      "target": 3,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 62,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 4,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    25
+                                  ]
+                                }
+                              ]
+                            }
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 64
+                    "span": 54
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
                             "projection": []
                           }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              55,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
                         }
-                      }
-                    },
-                    "span": 65
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 66
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 14,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      27,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 30
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
+                      "Assign": [
+                        {
+                          "local": 5,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "CheckedBinaryOp": [
+                            "Add",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 57
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 5,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                26
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          },
+                          {
+                            "Move": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        ]
+                      },
+                      "target": 5,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    25
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 57
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 6
+                    }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 58
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 60,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 28
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 60
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 6,
+          "name": "sum_to_n_rec"
+        }
+      },
+      "symbol_name": "_ZN16recursion_simple12sum_to_n_rec17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 13,
-                              "kind": "ZeroSized",
-                              "ty": 29
+                              "id": 12,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 4,
+                                  "bytes": [
+                                    10,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": []
+                                  }
+                                }
+                              },
+                              "ty": 25
                             },
-                            "span": 67,
+                            "span": 63,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 67
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 68,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 69,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 31
-                }
-              ],
-              "span": 70,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ans",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 69
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 62,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 64
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            55,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 65
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 66
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 14,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    27,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 30
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 13,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 67,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 67
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 68,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 69,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 31
+              }
+            ],
+            "span": 70,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ans",
+                "source_info": {
+                  "scope": 1,
+                  "span": 69
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 7,
           "name": "main"
         }
@@ -740,356 +736,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1100,359 +1094,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1463,177 +1455,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1644,83 +1634,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1731,63 +1719,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1798,155 +1784,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1957,35 +1941,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1996,92 +1978,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -91,356 +91,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -451,359 +449,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -814,177 +810,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -995,83 +989,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1082,63 +1074,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1149,155 +1139,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1308,35 +1296,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1347,92 +1333,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1443,275 +1427,273 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 16
-                                },
-                                "span": 51,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 53
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 3,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
-                        }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 11,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      25,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      42,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 26
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 4,
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 53
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 54
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    25,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 55,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 55
+                        }
+                      ],
+                      "destination": {
+                        "local": 4,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 55,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 55
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 57,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 58,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 28
+              }
+            ],
+            "span": 60,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 57
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 1
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 58
                 },
-                {
-                  "mutability": "Not",
-                  "span": 57,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 58,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 28
-                }
-              ],
-              "span": 60,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 57
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 58
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "c",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 59
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "c",
+                "source_info": {
+                  "scope": 3,
+                  "span": 59
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -359,356 +359,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -719,359 +717,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1082,177 +1078,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1263,83 +1257,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1350,63 +1342,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1417,155 +1407,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1576,35 +1564,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1615,92 +1601,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1711,114 +1695,181 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              },
-                              25
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 11,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          8,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 52,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 3,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 51,
+                                "user_ty": null
+                              }
+                            },
+                            25
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 11,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        8,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 25
+                                },
+                                "span": 52,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      128
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 2
+                              },
+                              "span": 50,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 51,
+                              "user_ty": null
+                            }
+                          }
+                        ]
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -1868,207 +1919,279 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 52
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 1,
-                                        "bytes": [
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 2
-                                  },
-                                  "span": 50,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 51,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
                         }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 3
                       }
-                    },
-                    "span": 53
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 55,
-                                  "user_ty": null
-                                }
-                              },
-                              25
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 13,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          16,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 56,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 7,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 55,
+                                "user_ty": null
+                              }
+                            },
+                            25
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 13,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        16,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 25
+                                },
+                                "span": 56,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 7,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 12,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 2,
+                                    "bytes": [
+                                      0,
+                                      128
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 26
+                              },
+                              "span": 54,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 55,
+                              "user_ty": null
+                            }
+                          }
+                        ]
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    35,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 4,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 57,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -2119,279 +2242,281 @@
                               }
                             }
                           ]
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 56
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 5,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            5
+                          ]
+                        ],
+                        "otherwise": 6
+                      }
+                    }
+                  },
+                  "span": 58
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 10,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 60,
+                                "user_ty": null
+                              }
+                            },
+                            25
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 61
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 11,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 10,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 17,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        32,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 25
+                                },
+                                "span": 61,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 61
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 11,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 15,
+                                "id": 16,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
                                       0,
                                       0,
                                       0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      35,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      128
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 16
+                              },
+                              "span": 59,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 28
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 60,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 4,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 7,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 61
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 18,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    38,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 57,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 12,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 2,
-                                        "bytes": [
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 26
-                                  },
-                                  "span": 54,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 55,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 5,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              5
-                            ]
-                          ],
-                          "otherwise": 6
                         }
-                      }
-                    },
-                    "span": 58
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 10,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 60,
-                                  "user_ty": null
-                                }
-                              },
-                              25
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 8,
+                        "projection": []
                       },
-                      "span": 61
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 11,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 27
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 10,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 17,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          32,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 61,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 62,
+                          "user_ty": null
+                        }
                       },
-                      "span": 61
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 62
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 11,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -2444,24 +2569,144 @@
                               }
                             }
                           ]
-                        },
-                        "target": 7,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 61
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 9,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            8
+                          ]
+                        ],
+                        "otherwise": 9
+                      }
+                    }
+                  },
+                  "span": 63
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 14,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 65,
+                                "user_ty": null
+                              }
+                            },
+                            25
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 66
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 15,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 14,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 20,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        64,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 25
+                                },
+                                "span": 66,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 66
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 15,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 18,
+                                "id": 19,
                                 "kind": {
                                   "Allocated": {
                                     "align": 8,
@@ -2473,252 +2718,136 @@
                                       0,
                                       0,
                                       0,
-                                      0,
-                                      38,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      128
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 29
+                              },
+                              "span": 64,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          1
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 28
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 65,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 8,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 10,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 66
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 21,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    43,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        2
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 62,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 62
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 16,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 59,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 60,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 61
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 9,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              8
-                            ]
-                          ],
-                          "otherwise": 9
                         }
-                      }
-                    },
-                    "span": 63
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 14,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 65,
-                                  "user_ty": null
-                                }
-                              },
-                              25
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 12,
+                        "projection": []
                       },
-                      "span": 66
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 15,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 27
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 14,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 20,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          64,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 66,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 67,
+                          "user_ty": null
+                        }
                       },
-                      "span": 66
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 67
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 15,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 13,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -2775,27 +2904,147 @@
                               }
                             }
                           ]
-                        },
-                        "target": 10,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 66
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 13,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            11
+                          ]
+                        ],
+                        "otherwise": 12
+                      }
+                    }
+                  },
+                  "span": 68
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
+                      "Assign": [
+                        {
+                          "local": 18,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 10,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        1,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 16
+                                },
+                                "span": 70,
+                                "user_ty": null
+                              }
+                            },
+                            25
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 71
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 19,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Move": {
+                                "local": 18,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 23,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 4,
+                                      "bytes": [
+                                        128,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 25
+                                },
+                                "span": 71,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 71
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 19,
+                          "projection": []
+                        }
+                      },
+                      "expected": true,
+                      "msg": {
+                        "Overflow": [
+                          "Shl",
                           {
                             "Constant": {
                               "const_": {
-                                "id": 21,
+                                "id": 22,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 16,
                                     "bytes": [
                                       0,
                                       0,
@@ -2805,255 +3054,143 @@
                                       0,
                                       0,
                                       0,
-                                      43,
                                       0,
                                       0,
                                       0,
                                       0,
+                                      0,
+                                      0,
+                                      0,
+                                      128
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 30
+                              },
+                              "span": 69,
+                              "user_ty": null
+                            }
+                          },
+                          {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 4,
+                                    "bytes": [
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          2
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 28
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 70,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 12,
-                          "projection": []
-                        },
-                        "func": {
+                        ]
+                      },
+                      "target": 13,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 71
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 24,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    52,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        3
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 67,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 67
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 13,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 19,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 8,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 29
-                                  },
-                                  "span": 64,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 65,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 66
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 13,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              11
-                            ]
-                          ],
-                          "otherwise": 12
                         }
-                      }
-                    },
-                    "span": 68
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 18,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 70,
-                                  "user_ty": null
-                                }
-                              },
-                              25
-                            ]
-                          }
-                        ]
+                      ],
+                      "destination": {
+                        "local": 16,
+                        "projection": []
                       },
-                      "span": 71
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 19,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 27
                           },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Move": {
-                                  "local": 18,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 23,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          128,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 71,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          "span": 72,
+                          "user_ty": null
+                        }
                       },
-                      "span": 71
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 72
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 19,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 17,
+                          "projection": []
                         },
-                        "expected": true,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "BinaryOp": [
                             "Shl",
                             {
                               "Constant": {
@@ -3118,380 +3255,225 @@
                               }
                             }
                           ]
-                        },
-                        "target": 13,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 71
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 24,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      52,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          3
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 28
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 16,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 17,
                           "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 72,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 72
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 17,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Shl",
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 22,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 16,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          128
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 30
-                                  },
-                                  "span": 69,
-                                  "user_ty": null
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 4,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 16
-                                  },
-                                  "span": 70,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 71
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 17,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              14
-                            ]
-                          ],
-                          "otherwise": 15
                         }
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 74
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 25,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      73,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          4
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 28
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            14
+                          ]
                         ],
-                        "destination": {
-                          "local": 20,
-                          "projection": []
-                        },
-                        "func": {
+                        "otherwise": 15
+                      }
+                    }
+                  },
+                  "span": 73
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 74
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 25,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    73,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        4
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 75,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 75
-                  }
+                        }
+                      ],
+                      "destination": {
+                        "local": 20,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 75,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 75
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 76,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 2
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 32
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 62,
-                  "ty": 32
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 61,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 32
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 32
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 71,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 71,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 71,
-                  "ty": 31
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 75,
-                  "ty": 32
-                }
-              ],
-              "span": 77,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 76,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 2
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 31
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 32
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 31
+              },
+              {
+                "mutability": "Mut",
+                "span": 62,
+                "ty": 32
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 61,
+                "ty": 31
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 32
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 31
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 32
+              },
+              {
+                "mutability": "Mut",
+                "span": 71,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 71,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 71,
+                "ty": 31
+              },
+              {
+                "mutability": "Mut",
+                "span": 75,
+                "ty": 32
+              }
+            ],
+            "span": 77,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "main"
         }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -161,891 +161,889 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      1,
-                                      0
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      0
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 13
-                      },
-                      "span": 0
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 13,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Lt",
-                              {
-                                "Copy": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 0
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 13,
-                            "projection": []
-                          }
+                      "StorageLive": 5
+                    },
+                    "span": 1
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              4
-                            ]
-                          ],
-                          "otherwise": 3
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    1,
+                                    0
+                                  ]
+                                }
+                              ]
+                            }
+                          }
                         }
-                      }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    0
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 13
+                    },
+                    "span": 0
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 13,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Lt",
+                            {
+                              "Copy": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 0
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 9,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 10,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 13,
                           "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 1
-                            },
-                            "span": 4,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 5
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 8
+                        }
                       },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 11
-                      },
-                      "span": 8
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 12
-                      },
-                      "span": 9
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 12,
-                            "projection": []
-                          },
-                          {
-                            "AddressOf": [
-                              "Not",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 9
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 15
-                      },
-                      "span": 8
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 16
-                      },
-                      "span": 10
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 16,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "PtrToPtr",
-                              {
-                                "Copy": {
-                                  "local": 12,
-                                  "projection": []
-                                }
-                              },
-                              2
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 11
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 15,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Offset",
-                              {
-                                "Copy": {
-                                  "local": 16,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 12
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 16
-                      },
-                      "span": 10
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 11,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "RawPtr": [
-                                  3,
-                                  "Not"
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 15,
-                                    "projection": []
-                                  }
-                                },
-                                {
-                                  "Copy": {
-                                    "local": 4,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 13
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 15
-                      },
-                      "span": 8
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 12
-                      },
-                      "span": 14
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 11,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 11
-                      },
-                      "span": 16
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 6
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 13
-                      },
-                      "span": 19
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 20
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 7,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          }
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            4
+                          ]
                         ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 4
-                            },
-                            "span": 17,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
+                        "otherwise": 3
                       }
-                    },
-                    "span": 18
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 14
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 14,
+                    }
+                  },
+                  "span": 0
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
                             "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "SubUnchecked",
-                              {
-                                "Copy": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              }
-                            ]
                           }
-                        ]
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  1,
-                                  1,
-                                  [
-                                    {
-                                      "Type": 0
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Move": {
-                                    "local": 14,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 14
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 13
-                      },
-                      "span": 19
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
-                                  {
-                                    "Downcast": 1
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      0
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 20
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 21
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+                        },
+                        {
+                          "Move": {
                             "local": 9,
                             "projection": []
-                          },
-                          {
-                            "UnaryOp": [
-                              "PtrMetadata",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              }
-                            ]
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 10,
+                        "projection": []
                       },
-                      "span": 27
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 1
                           },
-                          {
-                            "BinaryOp": [
-                              "Gt",
+                          "span": 4,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 5
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 11
+                    },
+                    "span": 8
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 12
+                    },
+                    "span": 9
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 12,
+                          "projection": []
+                        },
+                        {
+                          "AddressOf": [
+                            "Not",
+                            {
+                              "local": 2,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 9
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 15
+                    },
+                    "span": 8
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 16
+                    },
+                    "span": 10
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 16,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "PtrToPtr",
+                            {
+                              "Copy": {
+                                "local": 12,
+                                "projection": []
+                              }
+                            },
+                            2
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 11
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 15,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Offset",
+                            {
+                              "Copy": {
+                                "local": 16,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 12
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 16
+                    },
+                    "span": 10
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 11,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "RawPtr": [
+                                3,
+                                "Not"
+                              ]
+                            },
+                            [
                               {
                                 "Copy": {
-                                  "local": 6,
+                                  "local": 15,
                                   "projection": []
                                 }
                               },
                               {
                                 "Copy": {
-                                  "local": 9,
+                                  "local": 4,
                                   "projection": []
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 21
-                    }
-                  ],
-                  "terminator": {
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 13
+                  },
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
+                      "StorageDead": 15
+                    },
+                    "span": 8
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 12
+                    },
+                    "span": 14
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 11,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 11
+                    },
+                    "span": 16
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 6
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 13
+                    },
+                    "span": 19
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 20
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Move": {
-                            "local": 8,
+                            "local": 7,
                             "projection": []
                           }
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
                         }
-                      }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 4
+                          },
+                          "span": 17,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 18
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageLive": 14
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 14,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "SubUnchecked",
+                            {
+                              "Copy": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                1,
+                                1,
+                                [
+                                  {
+                                    "Type": 0
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            [
+                              {
+                                "Move": {
+                                  "local": 14,
+                                  "projection": []
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 14
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 13
+                    },
+                    "span": 19
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 1
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    0
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 20
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "UnaryOp": [
+                            "PtrMetadata",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 27
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Gt",
+                            {
+                              "Copy": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Copy": {
+                                "local": 9,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 21
                   }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 8,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
+                    }
+                  },
+                  "span": 21
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 5
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 29,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 30,
+                "ty": 5
+              },
+              {
+                "mutability": "Mut",
+                "span": 31,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 26,
+                "ty": 0
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 8
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 0
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 0
+              },
+              {
+                "mutability": "Mut",
+                "span": 21,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 27,
+                "ty": 0
+              },
+              {
+                "mutability": "Not",
+                "span": 5,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 8,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 9,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 0,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 0
+              },
+              {
+                "mutability": "Not",
+                "span": 32,
+                "ty": 2
+              },
+              {
+                "mutability": "Not",
+                "span": 33,
+                "ty": 2
+              }
+            ],
+            "span": 41,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 29
                 },
-                {
-                  "mutability": "Not",
-                  "span": 29,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 30,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 31,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 26,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 21,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 27,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Not",
-                  "span": 5,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 8,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 9,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 0,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Not",
-                  "span": 32,
-                  "ty": 2
-                },
-                {
-                  "mutability": "Not",
-                  "span": 33,
-                  "ty": 2
-                }
-              ],
-              "span": 41,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 29
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "slice",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 30
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "new_len",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 26
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 34
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 6,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "rhs",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 35
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 7,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "ptr",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 36
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "offset",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 37
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 7,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "len",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ptr",
-                  "source_info": {
-                    "scope": 4,
-                    "span": 32
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 15,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "ptr",
-                  "source_info": {
-                    "scope": 5,
-                    "span": 39
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "index",
-                  "source_info": {
-                    "scope": 5,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 7,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ptr",
-                  "source_info": {
-                    "scope": 6,
-                    "span": 33
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 16,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "slice",
+                "source_info": {
+                  "scope": 0,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "new_len",
+                "source_info": {
+                  "scope": 1,
+                  "span": 26
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 34
+                },
+                "value": {
+                  "Place": {
+                    "local": 6,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "rhs",
+                "source_info": {
+                  "scope": 2,
+                  "span": 35
+                },
+                "value": {
+                  "Place": {
+                    "local": 7,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "ptr",
+                "source_info": {
+                  "scope": 3,
+                  "span": 36
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "offset",
+                "source_info": {
+                  "scope": 3,
+                  "span": 37
+                },
+                "value": {
+                  "Place": {
+                    "local": 7,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "len",
+                "source_info": {
+                  "scope": 3,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ptr",
+                "source_info": {
+                  "scope": 4,
+                  "span": 32
+                },
+                "value": {
+                  "Place": {
+                    "local": 15,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "ptr",
+                "source_info": {
+                  "scope": 5,
+                  "span": 39
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "index",
+                "source_info": {
+                  "scope": 5,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 7,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ptr",
+                "source_info": {
+                  "scope": 6,
+                  "span": 33
+                },
+                "value": {
+                  "Place": {
+                    "local": 16,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index"
         }
@@ -1056,356 +1054,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 43
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 44
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 45
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  3,
-                                  [
-                                    {
-                                      "Type": 12
-                                    },
-                                    {
-                                      "Type": 13
-                                    },
-                                    {
-                                      "Type": 14
-                                    },
-                                    {
-                                      "Type": 15
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 45
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 44
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 44
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 11
-                            },
-                            "span": 42,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 43
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 47
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 44
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 45
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                3,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 12
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      17
-                                    ]
+                                    "Type": 13
+                                  },
+                                  {
+                                    "Type": 14
+                                  },
+                                  {
+                                    "Type": 15
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 45
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 44
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 44
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 11
+                          },
+                          "span": 42,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 47
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    17
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 48
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 49
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 49
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 46
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Not",
-                  "span": 51,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Not",
-                  "span": 53,
-                  "ty": 19
-                },
-                {
-                  "mutability": "Not",
-                  "span": 54,
-                  "ty": 20
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 21
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 45,
-                  "ty": 23
-                }
-              ],
-              "span": 55,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 51
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 52
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 53
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 54
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 48
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 49
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 49
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 46
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 51,
+                "ty": 18
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 53,
+                "ty": 19
+              },
+              {
+                "mutability": "Not",
+                "span": 54,
+                "ty": 20
+              },
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 21
+              },
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 45,
+                "ty": 23
+              }
+            ],
+            "span": 55,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 51
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 52
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 53
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 54
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 48
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::rt::lang_start::<()>"
         }
@@ -1416,359 +1412,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 58
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 59
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      18
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 59
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 3,
-                              "kind": "ZeroSized",
-                              "ty": 24
-                            },
-                            "span": 56,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 61
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 4,
-                              "kind": "ZeroSized",
-                              "ty": 25
-                            },
-                            "span": 60,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 58
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 63
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 64
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 64
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 65
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      20
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 59
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    18
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 65
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              27
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 66
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 67
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 68
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 69
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 62
+                    "span": 59
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 70,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 45,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 64,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 20
-                }
-              ],
-              "span": 45,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 51
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            18
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 24
+                          },
+                          "span": 56,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 57
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 61
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 4,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 60,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 58
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 63
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 64
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 71
+                    },
+                    "span": 64
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 72
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 65
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    20
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 65
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            27
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 66
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 67
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 68
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 69
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 62
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 70,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 45,
+                "ty": 22
+              },
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 12
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 64,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 20
+              }
+            ],
+            "span": 45,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 51
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          18
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 71
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 72
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 3,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1779,177 +1773,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 6,
-                                "kind": "ZeroSized",
-                                "ty": 12
-                              },
-                              "span": 74,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 5,
+                              "id": 6,
                               "kind": "ZeroSized",
-                              "ty": 30
+                              "ty": 12
                             },
-                            "span": 73,
+                            "span": 74,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 75
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 6,
-                                "kind": "ZeroSized",
-                                "ty": 12
-                              },
-                              "span": 74,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 31
-                            },
-                            "span": 76,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 77
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 78
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 79,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 80,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Not",
-                  "span": 81,
-                  "ty": 12
-                }
-              ],
-              "span": 84,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 80
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 82
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 83
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 6,
-                        "kind": "ZeroSized",
-                        "ty": 12
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 74,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 30
+                          },
+                          "span": 73,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 75
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 6,
+                              "kind": "ZeroSized",
+                              "ty": 12
+                            },
+                            "span": 74,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 31
+                          },
+                          "span": 76,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 77
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 78
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 79,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 80,
+                "ty": 18
+              },
+              {
+                "mutability": "Not",
+                "span": 81,
+                "ty": 12
+              }
+            ],
+            "span": 84,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 80
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 82
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 83
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 6,
+                      "kind": "ZeroSized",
+                      "ty": 12
+                    },
+                    "span": 74,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 4,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1960,83 +1952,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 8,
+                            "kind": "ZeroSized",
+                            "ty": 32
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 8,
-                              "kind": "ZeroSized",
-                              "ty": 32
-                            },
-                            "span": 85,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 85
-                  }
+                          "span": 85,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 85
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 85,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 33
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 12
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 85
                 }
-              ],
-              "span": 85,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 85,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 33
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 12
+              }
+            ],
+            "span": 85,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -2047,63 +2037,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 85
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 85
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 85,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 12
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 85
                 }
-              ],
-              "span": 85,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 85,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 18
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 12
+              }
+            ],
+            "span": 85,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -2114,155 +2102,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 85
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 85
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 9,
-                              "kind": "ZeroSized",
-                              "ty": 34
-                            },
-                            "span": 85,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 9,
+                            "kind": "ZeroSized",
+                            "ty": 34
+                          },
+                          "span": 85,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 85
-                  }
+                    }
+                  },
+                  "span": 85
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 85,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 23
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 35
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 85
                 }
-              ],
-              "span": 85,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 85
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 85
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 85
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 85,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 23
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 35
+              }
+            ],
+            "span": 85,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -2273,35 +2259,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 86
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 86
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 86,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 86,
-                  "ty": 33
-                }
-              ],
-              "span": 86,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 86,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 86,
+                "ty": 33
+              }
+            ],
+            "span": 86,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 6,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -2312,143 +2296,141 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 1,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 89
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 36
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
                             },
-                            "span": 87,
-                            "user_ty": null
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 89
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
                           }
                         },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 88
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 90
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 91,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 92,
-                  "ty": 37
-                },
-                {
-                  "mutability": "Not",
-                  "span": 93,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 89,
-                  "ty": 5
-                }
-              ],
-              "span": 94,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 92
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 36
+                          },
+                          "span": 87,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "index",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 93
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                  "span": 88
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 90
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 91,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 92,
+                "ty": 37
+              },
+              {
+                "mutability": "Not",
+                "span": 93,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 89,
+                "ty": 5
+              }
+            ],
+            "span": 94,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 92
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "index",
+                "source_info": {
+                  "scope": 0,
+                  "span": 93
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 7,
           "name": "std::array::<impl std::ops::Index<std::ops::Range<usize>> for [i32; 4]>::index"
         }
@@ -2459,95 +2441,1467 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 96
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 97
+                    "span": 96
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 9
-                      },
-                      "span": 98
+                    "span": 97
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 9
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 10
-                      },
-                      "span": 98
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 10
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 95
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 7
-                      },
-                      "span": 99
+                    "span": 95
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 7
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "UnaryOp": [
-                              "PtrMetadata",
+                    "span": 99
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "UnaryOp": [
+                            "PtrMetadata",
+                            {
+                              "Copy": {
+                                "local": 1,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 99
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Constant": {
+                                "const_": {
+                                  "id": 11,
+                                  "kind": {
+                                    "Allocated": {
+                                      "align": 8,
+                                      "bytes": [
+                                        2,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0
+                                      ],
+                                      "mutability": "Mut",
+                                      "provenance": {
+                                        "ptrs": []
+                                      }
+                                    }
+                                  },
+                                  "ty": 0
+                                },
+                                "span": 100,
+                                "user_ty": null
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 95
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 6,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 95
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 102
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 101
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 7
+                    },
+                    "span": 100
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 105
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 10,
+                          "projection": []
+                        },
+                        {
+                          "AddressOf": [
+                            "Not",
+                            {
+                              "local": 1,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 106
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "PtrToPtr",
+                            {
+                              "Copy": {
+                                "local": 10,
+                                "projection": []
+                              }
+                            },
+                            39
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 107
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 108
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                1,
+                                1,
+                                [
+                                  {
+                                    "Type": 40
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            [
                               {
                                 "Copy": {
-                                  "local": 1,
+                                  "local": 9,
                                   "projection": []
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 99
+                          ]
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
+                    "span": 109
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 110
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 111
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 10
+                    },
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 9
+                    },
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 11
+                    },
+                    "span": 112
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 11,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 1
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    40
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 113
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                9,
+                                0,
+                                [
+                                  {
+                                    "Type": 40
+                                  },
+                                  {
+                                    "Type": 41
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            [
                               {
-                                "Move": {
-                                  "local": 7,
+                                "Copy": {
+                                  "local": 11,
                                   "projection": []
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 114
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 11
+                    },
+                    "span": 112
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 115
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 3,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    40
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 116
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 12,
+                            "kind": "ZeroSized",
+                            "ty": 38
+                          },
+                          "span": 103,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 104
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 7
+                    },
+                    "span": 100
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 13,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 42
+                              },
+                              "span": 74,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 118
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 111
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 10
+                    },
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 9
+                    },
+                    "span": 98
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 11
+                    },
+                    "span": 112
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 14,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 43
+                              },
+                              "span": 74,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 119
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 11
+                    },
+                    "span": 112
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 115
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 15,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 9
+                              },
+                              "span": 117,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 117
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 1
+                    }
+                  },
+                  "span": 117
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 120,
+                "ty": 9
+              },
+              {
+                "mutability": "Not",
+                "span": 121,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 122,
+                "ty": 40
+              },
+              {
+                "mutability": "Not",
+                "span": 96,
+                "ty": 43
+              },
+              {
+                "mutability": "Not",
+                "span": 116,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 97,
+                "ty": 42
+              },
+              {
+                "mutability": "Mut",
+                "span": 95,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 99,
+                "ty": 0
+              },
+              {
+                "mutability": "Not",
+                "span": 105,
+                "ty": 39
+              },
+              {
+                "mutability": "Not",
+                "span": 123,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 124,
+                "ty": 10
+              },
+              {
+                "mutability": "Not",
+                "span": 113,
+                "ty": 40
+              }
+            ],
+            "span": 133,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 121
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "other",
+                "source_info": {
+                  "scope": 0,
+                  "span": 122
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 1,
+                  "span": 96
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 116
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 3,
+                  "span": 125
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "slice",
+                "source_info": {
+                  "scope": 4,
+                  "span": 126
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 5,
+                  "span": 127
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "ptr",
+                "source_info": {
+                  "scope": 6,
+                  "span": 105
+                },
+                "value": {
+                  "Place": {
+                    "local": 8,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "me",
+                "source_info": {
+                  "scope": 7,
+                  "span": 123
+                },
+                "value": {
+                  "Place": {
+                    "local": 8,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 8,
+                  "span": 128
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 9,
+                  "span": 129
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "err",
+                "source_info": {
+                  "scope": 9,
+                  "span": 130
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 16,
+                      "kind": "ZeroSized",
+                      "ty": 41
+                    },
+                    "span": 74,
+                    "user_ty": null
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 10,
+                  "span": 113
+                },
+                "value": {
+                  "Place": {
+                    "local": 11,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 11,
+                  "span": 131
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "other",
+                "source_info": {
+                  "scope": 11,
+                  "span": 132
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 8,
+          "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for [i32]>::eq"
+        }
+      },
+      "symbol_name": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 135
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 17,
+                            "kind": "ZeroSized",
+                            "ty": 44
+                          },
+                          "span": 134,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 134
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 136
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 137,
+                "ty": 9
+              },
+              {
+                "mutability": "Not",
+                "span": 138,
+                "ty": 45
+              },
+              {
+                "mutability": "Not",
+                "span": 139,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 138,
+                "ty": 5
+              }
+            ],
+            "span": 140,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 138
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "other",
+                "source_info": {
+                  "scope": 0,
+                  "span": 139
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 10,
+          "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for &[i32]>::eq"
+        }
+      },
+      "symbol_name": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 18,
+                            "kind": "ZeroSized",
+                            "ty": 46
+                          },
+                          "span": 141,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 142
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 143
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 144,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 145,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 146,
+                "ty": 6
+              }
+            ],
+            "span": 147,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 145
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "index",
+                "source_info": {
+                  "scope": 0,
+                  "span": 146
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 11,
+          "name": "core::slice::index::<impl std::ops::Index<std::ops::Range<usize>> for [i32]>::index"
+        }
+      },
+      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 19,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 28
+                              },
+                              "span": 149,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 149
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 148
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 150,
+                "ty": 28
+              },
+              {
+                "mutability": "Not",
+                "span": 151,
+                "ty": 12
+              }
+            ],
+            "span": 152,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 151
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 6,
+                      "kind": "ZeroSized",
+                      "ty": 12
+                    },
+                    "span": 74,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
+          "id": 12,
+          "name": "<() as std::process::Termination>::report"
+        }
+      },
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Array": 27
+                            },
+                            [
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 22,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          1,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 27
+                                  },
+                                  "span": 163,
+                                  "user_ty": null
                                 }
                               },
                               {
                                 "Constant": {
                                   "const_": {
-                                    "id": 11,
+                                    "id": 23,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          2,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 27
+                                  },
+                                  "span": 164,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 24,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          3,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 27
+                                  },
+                                  "span": 165,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 25,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          4,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 27
+                                  },
+                                  "span": 166,
+                                  "user_ty": null
+                                }
+                              }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 167
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 168
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                15,
+                                0,
+                                [
+                                  {
+                                    "Type": 0
+                                  }
+                                ],
+                                null,
+                                null
+                              ]
+                            },
+                            [
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 26,
                                     "kind": {
                                       "Allocated": {
                                         "align": 8,
                                         "bytes": [
-                                          2,
+                                          1,
                                           0,
                                           0,
                                           0,
@@ -2564,1653 +3918,147 @@
                                     },
                                     "ty": 0
                                   },
-                                  "span": 100,
+                                  "span": 169,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 27,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 8,
+                                        "bytes": [
+                                          3,
+                                          0,
+                                          0,
+                                          0,
+                                          0,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 0
+                                  },
+                                  "span": 170,
                                   "user_ty": null
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 95
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 6,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
+                      ]
                     },
-                    "span": 95
+                    "span": 171
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 102
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 101
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 7
-                      },
-                      "span": 100
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 105
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 10,
-                            "projection": []
-                          },
-                          {
-                            "AddressOf": [
-                              "Not",
-                              {
-                                "local": 1,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 106
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "PtrToPtr",
-                              {
-                                "Copy": {
-                                  "local": 10,
-                                  "projection": []
-                                }
-                              },
-                              39
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 107
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 108
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  1,
-                                  1,
-                                  [
-                                    {
-                                      "Type": 40
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 9,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 109
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 110
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 111
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 10
-                      },
-                      "span": 98
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 9
-                      },
-                      "span": 98
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 11
-                      },
-                      "span": 112
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 11,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 5,
-                                "projection": [
-                                  {
-                                    "Downcast": 1
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      40
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 113
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  9,
-                                  0,
-                                  [
-                                    {
-                                      "Type": 40
-                                    },
-                                    {
-                                      "Type": 41
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 11,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 114
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 11
-                      },
-                      "span": 112
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 115
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 4,
                             "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 3,
-                                "projection": [
-                                  {
-                                    "Downcast": 0
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      40
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 116
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 12,
-                              "kind": "ZeroSized",
-                              "ty": 38
-                            },
-                            "span": 103,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 104
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 7
-                      },
-                      "span": 100
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+                        {
+                          "Move": {
                             "local": 5,
                             "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 13,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 42
-                                },
-                                "span": 74,
-                                "user_ty": null
-                              }
-                            }
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
                       },
-                      "span": 118
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 111
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 10
-                      },
-                      "span": 98
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 9
-                      },
-                      "span": 98
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 11
-                      },
-                      "span": 112
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 21,
+                            "kind": "ZeroSized",
+                            "ty": 48
                           },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 14,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 43
-                                },
-                                "span": 74,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
+                          "span": 162,
+                          "user_ty": null
+                        }
                       },
-                      "span": 119
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 11
-                      },
-                      "span": 112
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 115
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 15,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 9
-                                },
-                                "span": 117,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 117
+                      "target": 1,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 162
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Goto": {
-                        "target": 1
-                      }
-                    },
-                    "span": 117
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 120,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Not",
-                  "span": 121,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 122,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Not",
-                  "span": 96,
-                  "ty": 43
-                },
-                {
-                  "mutability": "Not",
-                  "span": 116,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 97,
-                  "ty": 42
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 95,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 99,
-                  "ty": 0
-                },
-                {
-                  "mutability": "Not",
-                  "span": 105,
-                  "ty": 39
-                },
-                {
-                  "mutability": "Not",
-                  "span": 123,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 124,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Not",
-                  "span": 113,
-                  "ty": 40
-                }
-              ],
-              "span": 133,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 121
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "other",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 122
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 96
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 116
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 125
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "slice",
-                  "source_info": {
-                    "scope": 4,
-                    "span": 126
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 5,
-                    "span": 127
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "ptr",
-                  "source_info": {
-                    "scope": 6,
-                    "span": 105
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 8,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "me",
-                  "source_info": {
-                    "scope": 7,
-                    "span": 123
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 8,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 8,
-                    "span": 128
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 9,
-                    "span": 129
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "err",
-                  "source_info": {
-                    "scope": 9,
-                    "span": 130
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 16,
-                        "kind": "ZeroSized",
-                        "ty": 41
-                      },
-                      "span": 74,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 10,
-                    "span": 113
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 11,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 11,
-                    "span": 131
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "other",
-                  "source_info": {
-                    "scope": 11,
-                    "span": 132
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 8,
-          "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for [i32]>::eq"
-        }
-      },
-      "symbol_name": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 135
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
                               "local": 3,
                               "projection": []
                             }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 17,
-                              "kind": "ZeroSized",
-                              "ty": 44
-                            },
-                            "span": 134,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 134
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 136
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 137,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Not",
-                  "span": 138,
-                  "ty": 45
-                },
-                {
-                  "mutability": "Not",
-                  "span": 139,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 138,
-                  "ty": 5
-                }
-              ],
-              "span": 140,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 138
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "other",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 139
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 10,
-          "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for &[i32]>::eq"
-        }
-      },
-      "symbol_name": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 18,
-                              "kind": "ZeroSized",
-                              "ty": 46
-                            },
-                            "span": 141,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 142
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 143
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 144,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 145,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 146,
-                  "ty": 6
-                }
-              ],
-              "span": 147,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 145
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "index",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 146
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 11,
-          "name": "core::slice::index::<impl std::ops::Index<std::ops::Range<usize>> for [i32]>::index"
-        }
-      },
-      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 19,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 28
-                                },
-                                "span": 149,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 149
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 148
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 150,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Not",
-                  "span": 151,
-                  "ty": 12
-                }
-              ],
-              "span": 152,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 151
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 6,
-                        "kind": "ZeroSized",
-                        "ty": 12
-                      },
-                      "span": 74,
-                      "user_ty": null
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 12,
-          "name": "<() as std::process::Termination>::report"
-        }
-      },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Array": 27
-                              },
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 22,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            1,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 163,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 23,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            2,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 164,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 24,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            3,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 165,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 25,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            4,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 166,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 167
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 168
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  15,
-                                  0,
-                                  [
-                                    {
-                                      "Type": 0
-                                    }
-                                  ],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 26,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 8,
-                                          "bytes": [
-                                            1,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 0
-                                    },
-                                    "span": 169,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 27,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 8,
-                                          "bytes": [
-                                            3,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 0
-                                    },
-                                    "span": 170,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 171
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 5,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 21,
-                              "kind": "ZeroSized",
-                              "ty": 48
-                            },
-                            "span": 162,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 162
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 3,
-                                "projection": []
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 173
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 174
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 29,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": [
-                                          [
-                                            0,
-                                            0
-                                          ]
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  "ty": 40
-                                },
-                                "span": 175,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 175
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 7,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 8,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 6,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 28,
-                              "kind": "ZeroSized",
-                              "ty": 49
-                            },
-                            "span": 172,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 172
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 6,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              4
-                            ]
-                          ],
-                          "otherwise": 3
                         }
-                      }
+                      ]
                     },
-                    "span": 172
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 176
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                    "span": 173
+                  },
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 174
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 31,
+                                "id": 29,
                                 "kind": {
                                   "Allocated": {
                                     "align": 8,
                                     "bytes": [
                                       0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      29,
                                       0,
                                       0,
                                       0,
@@ -4224,251 +4072,254 @@
                                       "ptrs": [
                                         [
                                           0,
-                                          1
+                                          0
                                         ]
                                       ]
                                     }
                                   }
                                 },
-                                "ty": 51
+                                "ty": 40
                               },
-                              "span": 74,
+                              "span": 175,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 9,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 30,
-                              "kind": "ZeroSized",
-                              "ty": 50
-                            },
-                            "span": 177,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 177
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 178,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 179,
-                  "ty": 52
-                },
-                {
-                  "mutability": "Not",
-                  "span": 180,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 162,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 168,
-                  "ty": 37
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 171,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 172,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 174,
-                  "ty": 45
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 175,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 177,
-                  "ty": 7
-                }
-              ],
-              "span": 181,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 179
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 180
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Array": 27
-                              },
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 23,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            2,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 182,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 24,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            3,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 27
-                                    },
-                                    "span": 183,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 175
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 175
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
                     "span": 175
                   }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 7,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 8,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 6,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 28,
+                            "kind": "ZeroSized",
+                            "ty": 49
+                          },
+                          "span": 172,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 172
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 175,
-                  "ty": 40
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 6,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            4
+                          ]
+                        ],
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 172
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 176
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 31,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    29,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 51
+                            },
+                            "span": 74,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 9,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 30,
+                            "kind": "ZeroSized",
+                            "ty": 50
+                          },
+                          "span": 177,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 177
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 178,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 179,
+                "ty": 52
+              },
+              {
+                "mutability": "Not",
+                "span": 180,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 162,
+                "ty": 5
+              },
+              {
+                "mutability": "Mut",
+                "span": 168,
+                "ty": 37
+              },
+              {
+                "mutability": "Mut",
+                "span": 171,
+                "ty": 6
+              },
+              {
+                "mutability": "Mut",
+                "span": 172,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 174,
+                "ty": 45
+              },
+              {
+                "mutability": "Mut",
+                "span": 175,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 177,
+                "ty": 7
+              }
+            ],
+            "span": 181,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 179
                 },
-                {
-                  "mutability": "Mut",
-                  "span": 175,
-                  "ty": 53
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
                 }
-              ],
-              "span": 175,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 180
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 14,
           "name": "main"
         }
@@ -4479,154 +4330,152 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 155
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "Transmute",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              40
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 155
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
+                      "StorageLive": 3
+                    },
+                    "span": 155
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 20,
-                              "kind": "ZeroSized",
-                              "ty": 47
+                        {
+                          "Cast": [
+                            "Transmute",
+                            {
+                              "Copy": {
+                                "local": 2,
+                                "projection": []
+                              }
                             },
-                            "span": 153,
-                            "user_ty": null
+                            40
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 155
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
                         },
-                        "target": 1,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 154
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 157
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 20,
+                            "kind": "ZeroSized",
+                            "ty": 47
+                          },
+                          "span": 153,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Unreachable"
                     }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 156
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 158,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Not",
-                  "span": 159,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Not",
-                  "span": 160,
-                  "ty": 40
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 155,
-                  "ty": 40
-                }
-              ],
-              "span": 161,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 159
                   },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
+                  "span": 154
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 157
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 156
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 158,
+                "ty": 9
+              },
+              {
+                "mutability": "Not",
+                "span": 159,
+                "ty": 40
+              },
+              {
+                "mutability": "Not",
+                "span": 160,
+                "ty": 40
+              },
+              {
+                "mutability": "Mut",
+                "span": 155,
+                "ty": 40
+              }
+            ],
+            "span": 161,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 0,
+                  "span": 159
                 },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 160
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 0,
+                  "span": 160
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 13,
           "name": "<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq"
         }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -92,331 +92,329 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 4,
-                                      "bytes": [
-                                        42,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 16
-                                },
-                                "span": 51,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 53
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "CopyForDeref": {
-                              "local": 3,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
-                          }
-                        ]
-                      },
-                      "span": 53
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 6,
-                                "projection": []
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 55
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 4,
-                            "projection": []
-                          }
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              42,
-                              1
-                            ]
-                          ],
-                          "otherwise": 2
-                        }
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 11,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      26,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      42,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 26
+                                "ty": 16
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 5,
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "CopyForDeref": {
+                            "local": 3,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 6,
+                              "projection": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 54
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                "Deref"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 55
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 4,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            42,
+                            1
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 10,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 11,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    26,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 57,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Not",
-                  "span": 53,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 27
-                }
-              ],
-              "span": 61,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "a",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 59
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 10,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 57,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "b",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 60
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                  "span": 57
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 27
+              },
+              {
+                "mutability": "Not",
+                "span": 53,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 27
+              }
+            ],
+            "span": 61,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "a",
+                "source_info": {
+                  "scope": 1,
+                  "span": 59
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "b",
+                "source_info": {
+                  "scope": 2,
+                  "span": 60
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -427,356 +425,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -787,359 +783,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1150,177 +1144,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1331,83 +1323,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1418,63 +1408,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1485,155 +1473,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1644,35 +1630,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1683,92 +1667,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -98,356 +98,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -458,359 +456,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -821,177 +817,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1002,83 +996,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1089,63 +1081,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1156,155 +1146,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1315,35 +1303,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1354,92 +1340,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1450,130 +1434,30 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Adt": [
-                                  7,
-                                  0,
-                                  [],
-                                  null,
-                                  null
-                                ]
-                              },
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 9,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            1,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 26
-                                    },
-                                    "span": 52,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 10,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            2,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 26
-                                    },
-                                    "span": 53,
-                                    "user_ty": null
-                                  }
-                                }
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Adt": [
+                                7,
+                                0,
+                                [],
+                                null,
+                                null
                               ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              },
+                            },
+                            [
                               {
                                 "Constant": {
                                   "const_": {
@@ -1595,39 +1479,80 @@
                                     },
                                     "ty": 26
                                   },
-                                  "span": 50,
+                                  "span": 52,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 10,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          2,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 26
+                                  },
+                                  "span": 53,
                                   "user_ty": null
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 51
-                    }
-                  ],
-                  "terminator": {
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 54
+                  },
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 5,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  25
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 4,
                                 "projection": []
                               }
@@ -1658,262 +1583,319 @@
                               }
                             }
                           ]
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 51
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Move": {
-                                "local": 5,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 5,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                25
+                              ]
                             }
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      1,
-                                      26
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
-                    },
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 58
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
+                          {
+                            "Move": {
+                              "local": 4,
+                              "projection": []
+                            }
+                          },
                           {
                             "Constant": {
                               "const_": {
-                                "id": 12,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
-                                    "align": 8,
+                                    "align": 4,
                                     "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
+                                      1,
                                       0,
                                       0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 28
+                                "ty": 26
                               },
-                              "span": 32,
+                              "span": 50,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 7,
+                        ]
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 51
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
                           "projection": []
                         },
-                        "func": {
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    1,
+                                    26
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 58
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                              "id": 12,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 28
                             },
-                            "span": 59,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 59
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 61,
-                  "ty": 29
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 51,
-                  "ty": 30
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 31
-                }
-              ],
-              "span": 62,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "s",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 61
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 7,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 59,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 59
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 61,
+                "ty": 29
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 51,
+                "ty": 30
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 31
+              }
+            ],
+            "span": 62,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "s",
+                "source_info": {
+                  "scope": 1,
+                  "span": 61
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -100,356 +100,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -460,359 +458,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -823,177 +819,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1004,83 +998,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1091,63 +1083,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1158,155 +1148,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1317,35 +1305,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1356,92 +1342,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }
@@ -1452,194 +1436,482 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 12,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      10,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
+                                  }
+                                },
+                                "ty": 25
+                              },
+                              "span": 71,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 72
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 28
                           },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 12,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        10,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                          "span": 69,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 70
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 13,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      55,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 25
+                                  }
                                 },
-                                "span": 71,
-                                "user_ty": null
+                                "ty": 25
+                              },
+                              "span": 74,
+                              "user_ty": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 75
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 2,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
                               }
                             }
-                          }
-                        ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 76
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Copy": {
+                          "local": 1,
+                          "projection": []
+                        }
                       },
-                      "span": 72
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
                         ],
-                        "destination": {
+                        "otherwise": 3
+                      }
+                    }
+                  },
+                  "span": 73
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 15,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    24,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 30
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 14,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 77,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 77
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 78
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 79,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 80,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 70,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 75,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 77,
+                "ty": 31
+              }
+            ],
+            "span": 83,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 1,
+                  "span": 81
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 12,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            10,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 25
+                    },
+                    "span": 71,
+                    "user_ty": null
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "golden",
+                "source_info": {
+                  "scope": 2,
+                  "span": 82
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 13,
+                      "kind": {
+                        "Allocated": {
+                          "align": 8,
+                          "bytes": [
+                            55,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                          ],
+                          "mutability": "Mut",
+                          "provenance": {
+                            "ptrs": []
+                          }
+                        }
+                      },
+                      "ty": 25
+                    },
+                    "span": 74,
+                    "user_ty": null
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "sucess",
+                "source_info": {
+                  "scope": 3,
+                  "span": 80
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
+          "id": 7,
+          "name": "test_sum_to_n"
+        }
+      },
+      "symbol_name": "_ZN8sum_to_n13test_sum_to_n17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 16,
+                            "kind": "ZeroSized",
+                            "ty": 32
+                          },
+                          "span": 84,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 85
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 86
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 87,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 1
+              }
+            ],
+            "span": 88,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
+          "id": 8,
+          "name": "main"
+        }
+      },
+      "symbol_name": "_ZN8sum_to_n4main17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
                           "local": 2,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 28
-                            },
-                            "span": 69,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 70
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 13,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        55,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
-                                    }
-                                  },
-                                  "ty": 25
-                                },
-                                "span": 74,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 75
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 76
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Copy": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 3
-                        }
-                      }
-                    },
-                    "span": 73
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 15,
+                                "id": 9,
                                 "kind": {
                                   "Allocated": {
                                     "align": 8,
@@ -1651,285 +1923,92 @@
                                       0,
                                       0,
                                       0,
-                                      0,
-                                      24,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
                                       0
                                     ],
                                     "mutability": "Mut",
                                     "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
+                                      "ptrs": []
                                     }
                                   }
                                 },
-                                "ty": 30
+                                "ty": 25
                               },
-                              "span": 32,
+                              "span": 51,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
+                        }
+                      ]
+                    },
+                    "span": 51
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 1
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
                           "local": 5,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 14,
-                              "kind": "ZeroSized",
-                              "ty": 29
-                            },
-                            "span": 77,
-                            "user_ty": null
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 3,
+                              "projection": []
+                            }
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 77
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 78
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 79,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 80,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 70,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 75,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 77,
-                  "ty": 31
-                }
-              ],
-              "span": 83,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 81
+                    "span": 54
                   },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 12,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              10,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 25
-                      },
-                      "span": 71,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "golden",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 82
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 13,
-                        "kind": {
-                          "Allocated": {
-                            "align": 8,
-                            "bytes": [
-                              55,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0,
-                              0
-                            ],
-                            "mutability": "Mut",
-                            "provenance": {
-                              "ptrs": []
-                            }
-                          }
-                        },
-                        "ty": 25
-                      },
-                      "span": 74,
-                      "user_ty": null
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "sucess",
-                  "source_info": {
-                    "scope": 3,
-                    "span": 80
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            }
-          ],
-          "id": 7,
-          "name": "test_sum_to_n"
-        }
-      },
-      "symbol_name": "_ZN8sum_to_n13test_sum_to_n17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 1,
+                      "Assign": [
+                        {
+                          "local": 4,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 16,
-                              "kind": "ZeroSized",
-                              "ty": 32
+                        {
+                          "BinaryOp": [
+                            "Gt",
+                            {
+                              "Move": {
+                                "local": 5,
+                                "projection": []
+                              }
                             },
-                            "span": 84,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 85
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 86
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 87,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 85,
-                  "ty": 1
-                }
-              ],
-              "span": 88,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
-          "id": 8,
-          "name": "main"
-        }
-      },
-      "symbol_name": "_ZN8sum_to_n4main17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
+                            {
                               "Constant": {
                                 "const_": {
                                   "id": 9,
@@ -1954,209 +2033,70 @@
                                   },
                                   "ty": 25
                                 },
-                                "span": 51,
+                                "span": 55,
                                 "user_ty": null
                               }
                             }
-                          }
-                        ]
-                      },
-                      "span": 51
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": []
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 1
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 3,
-                                "projection": []
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Gt",
-                              {
-                                "Move": {
-                                  "local": 5,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 9,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 8,
-                                        "bytes": [
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 55,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 53
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 4,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              5
-                            ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
+                      ]
                     },
                     "span": 53
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 3,
-                                "projection": []
-                              }
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 4,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            5
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 53
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 3,
+                              "projection": []
                             }
                           }
-                        ]
-                      },
-                      "span": 57
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Add",
-                              {
-                                "Copy": {
-                                  "local": 2,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Copy": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
+                    "span": 57
+                  },
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 7,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  26
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "CheckedBinaryOp": [
                             "Add",
                             {
                               "Copy": {
@@ -2165,141 +2105,118 @@
                               }
                             },
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 6,
                                 "projection": []
                               }
                             }
                           ]
-                        },
-                        "target": 3,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 56
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 7,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                26
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Add",
                           {
-                            "local": 2,
-                            "projection": []
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 7,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      25
-                                    ]
-                                  }
-                                ]
-                              }
+                            "Move": {
+                              "local": 6,
+                              "projection": []
                             }
                           }
                         ]
                       },
-                      "span": 56
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 3,
-                                "projection": []
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 60
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 9,
-                            "projection": []
-                          },
-                          {
-                            "CheckedBinaryOp": [
-                              "Sub",
-                              {
-                                "Copy": {
-                                  "local": 8,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Constant": {
-                                  "const_": {
-                                    "id": 10,
-                                    "kind": {
-                                      "Allocated": {
-                                        "align": 8,
-                                        "bytes": [
-                                          1,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0,
-                                          0
-                                        ],
-                                        "mutability": "Mut",
-                                        "provenance": {
-                                          "ptrs": []
-                                        }
-                                      }
-                                    },
-                                    "ty": 25
-                                  },
-                                  "span": 58,
-                                  "user_ty": null
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 59
+                      "target": 3,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 56
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Assert": {
-                        "cond": {
-                          "Move": {
-                            "local": 9,
-                            "projection": [
-                              {
-                                "Field": [
-                                  1,
-                                  26
-                                ]
-                              }
-                            ]
-                          }
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
                         },
-                        "expected": false,
-                        "msg": {
-                          "Overflow": [
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 7,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    25
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 56
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 3,
+                              "projection": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 60
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 9,
+                          "projection": []
+                        },
+                        {
+                          "CheckedBinaryOp": [
                             "Sub",
                             {
-                              "Move": {
+                              "Copy": {
                                 "local": 8,
                                 "projection": []
                               }
@@ -2334,183 +2251,244 @@
                               }
                             }
                           ]
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
                     "span": 59
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
+                ],
+                "terminator": {
+                  "kind": {
+                    "Assert": {
+                      "cond": {
+                        "Move": {
+                          "local": 9,
+                          "projection": [
+                            {
+                              "Field": [
+                                1,
+                                26
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "expected": false,
+                      "msg": {
+                        "Overflow": [
+                          "Sub",
                           {
-                            "local": 3,
-                            "projection": []
+                            "Move": {
+                              "local": 8,
+                              "projection": []
+                            }
                           },
                           {
-                            "Use": {
-                              "Move": {
-                                "local": 9,
-                                "projection": [
-                                  {
-                                    "Field": [
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 8,
+                                    "bytes": [
+                                      1,
                                       0,
-                                      25
-                                    ]
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
+                                    }
                                   }
-                                ]
-                              }
+                                },
+                                "ty": 25
+                              },
+                              "span": 58,
+                              "user_ty": null
                             }
                           }
                         ]
                       },
-                      "span": 61
+                      "target": 4,
+                      "unwind": "Continue"
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 59
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Goto": {
-                        "target": 1
-                      }
-                    },
-                    "span": 50
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": []
-                              }
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Move": {
+                              "local": 9,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    25
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 63
+                        }
+                      ]
+                    },
+                    "span": 61
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 1
                     }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 62
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": []
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 63
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 62
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 64,
+                "ty": 25
+              },
+              {
+                "mutability": "Not",
+                "span": 65,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 66,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 67,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 26
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 60,
+                "ty": 25
+              },
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 27
+              }
+            ],
+            "span": 68,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "n",
+                "source_info": {
+                  "scope": 0,
+                  "span": 65
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 64,
-                  "ty": 25
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "sum",
+                "source_info": {
+                  "scope": 1,
+                  "span": 66
                 },
-                {
-                  "mutability": "Not",
-                  "span": 65,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 66,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 67,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 26
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 60,
-                  "ty": 25
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 27
-                }
-              ],
-              "span": 68,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "n",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 65
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "sum",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 66
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "counter",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 67
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "counter",
+                "source_info": {
+                  "scope": 2,
+                  "span": 67
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "sum_to_n"
         }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -130,356 +130,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -490,359 +488,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -853,177 +849,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1034,176 +1028,174 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 44
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
+                    "span": 44
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref"
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 44
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 45
+                    "span": 44
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  "Deref"
-                                ]
-                              }
+                    "span": 45
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                "Deref"
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 45
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Eq",
-                              {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
-                                }
-                              },
-                              {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
-                                }
+                    "span": 45
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Eq",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
                               }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 46
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 47
+                    "span": 46
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 4
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 47
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 48,
-                  "ty": 21
-                },
-                {
-                  "mutability": "Not",
-                  "span": 49,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 50,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 45,
-                  "ty": 16
-                }
-              ],
-              "span": 51,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 49
+                    "span": 47
                   },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 47
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 48,
+                "ty": 21
+              },
+              {
+                "mutability": "Not",
+                "span": 49,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 50,
+                "ty": 22
+              },
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 45,
+                "ty": 16
+              }
+            ],
+            "span": 51,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 49
                 },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "other",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 50
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "other",
+                "source_info": {
+                  "scope": 0,
+                  "span": 50
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 3,
           "name": "std::cmp::impls::<impl std::cmp::PartialEq for i32>::eq"
         }
@@ -1214,83 +1206,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 23
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 52,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 52
-                  }
+                          "span": 52,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 24
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 52
                 }
-              ],
-              "span": 52,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 24
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 1
+              }
+            ],
+            "span": 52,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1301,63 +1291,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 52
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 52
                 }
-              ],
-              "span": 52,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 1
+              }
+            ],
+            "span": 52,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1368,155 +1356,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 52
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 52
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 25
-                            },
-                            "span": 52,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 52,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 52
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 52
-                  }
+                    }
+                  },
+                  "span": 52
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 52,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 52,
-                  "ty": 26
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
                 }
-              ],
-              "span": 52,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 52
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 52
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 26
+              }
+            ],
+            "span": 52,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1527,35 +1513,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 53
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 53
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 53,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 53,
-                  "ty": 24
-                }
-              ],
-              "span": 53,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 53,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 53,
+                "ty": 24
+              }
+            ],
+            "span": 53,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 5,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1566,461 +1550,459 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 56
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 5,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
+                      "StorageLive": 3
+                    },
+                    "span": 54
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 8,
-                              "kind": "ZeroSized",
-                              "ty": 27
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
                             },
-                            "span": 54,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     },
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                    "span": 55
+                  },
+                  {
                     "kind": {
-                      "SwitchInt": {
-                        "discr": {
+                      "StorageLive": 5
+                    },
+                    "span": 56
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Move": {
-                            "local": 3,
+                            "local": 4,
                             "projection": []
                           }
                         },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              3
-                            ]
-                          ],
-                          "otherwise": 2
+                        {
+                          "Move": {
+                            "local": 5,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 8,
+                            "kind": "ZeroSized",
+                            "ty": 27
+                          },
+                          "span": 54,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 3,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
+                        ],
+                        "otherwise": 2
                       }
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 5
                     },
-                    "span": 54
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    1,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 7
+                    },
+                    "span": 56
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    1,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 56
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 6,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      1,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
                           }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 7
-                      },
-                      "span": 56
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+                        },
+                        {
+                          "Move": {
                             "local": 7,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      1,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
                           }
-                        ]
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 56
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 8,
+                            "kind": "ZeroSized",
+                            "ty": 27
                           },
-                          {
-                            "Move": {
-                              "local": 7,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
+                          "span": 54,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 4,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 57
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
                           "local": 0,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 8,
-                              "kind": "ZeroSized",
-                              "ty": 27
-                            },
-                            "span": 54,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 4,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 9,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 9,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 21
+                                  }
                                 },
-                                "span": 54,
-                                "user_ty": null
-                              }
+                                "ty": 21
+                              },
+                              "span": 54,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 54
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Goto": {
-                        "target": 5
-                      }
+                        }
+                      ]
                     },
                     "span": 54
                   }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 7
-                      },
-                      "span": 57
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 57
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 5
                     }
-                  ],
-                  "terminator": {
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Goto": {
-                        "target": 5
-                      }
+                      "StorageDead": 7
                     },
-                    "span": 54
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 57
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 58
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 59,
-                  "ty": 21
-                },
-                {
-                  "mutability": "Not",
-                  "span": 60,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Not",
-                  "span": 61,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 21
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 56,
-                  "ty": 22
-                }
-              ],
-              "span": 62,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 60
+                    "span": 57
                   },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 57
                   }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "other",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 61
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
+                ],
+                "terminator": {
+                  "kind": {
+                    "Goto": {
+                      "target": 5
                     }
+                  },
+                  "span": 54
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 57
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 58
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 59,
+                "ty": 21
+              },
+              {
+                "mutability": "Not",
+                "span": 60,
+                "ty": 28
+              },
+              {
+                "mutability": "Not",
+                "span": 61,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 21
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 22
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 22
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 22
+              },
+              {
+                "mutability": "Mut",
+                "span": 56,
+                "ty": 22
+              }
+            ],
+            "span": 62,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 60
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "other",
+                "source_info": {
+                  "scope": 0,
+                  "span": 61
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 6,
           "name": "core::tuple::<impl std::cmp::PartialEq for (i32, i32)>::eq"
         }
@@ -2031,92 +2013,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 10,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 10,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 64,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 64,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 64
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 63
+                        }
+                      ]
+                    },
+                    "span": 64
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 63
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 65,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 65,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 66,
+                "ty": 1
+              }
+            ],
+            "span": 67,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 66
                 },
-                {
-                  "mutability": "Not",
-                  "span": 66,
-                  "ty": 1
-                }
-              ],
-              "span": 67,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 66
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 7,
           "name": "<() as std::process::Termination>::report"
         }
@@ -2127,245 +2107,119 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              "Tuple",
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 12,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            42,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 69,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 13,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            99,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 70,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 71
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 72
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 14,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 8,
-                                      "bytes": [
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": [
-                                          [
-                                            0,
-                                            0
-                                          ]
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  "ty": 28
-                                },
-                                "span": 73,
-                                "user_ty": null
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 73
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
+                      "Assign": [
+                        {
+                          "local": 1,
                           "projection": []
                         },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 29
-                            },
-                            "span": 68,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 68
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
+                        {
+                          "Aggregate": [
+                            "Tuple",
                             [
-                              0,
-                              3
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 12,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          42,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 69,
+                                  "user_ty": null
+                                }
+                              },
+                              {
+                                "Constant": {
+                                  "const_": {
+                                    "id": 13,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          99,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 70,
+                                  "user_ty": null
+                                }
+                              }
                             ]
-                          ],
-                          "otherwise": 2
+                          ]
                         }
-                      }
+                      ]
                     },
-                    "span": 68
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 74
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
+                    "span": 71
+                  },
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 72
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
                             "Constant": {
                               "const_": {
-                                "id": 16,
+                                "id": 14,
                                 "kind": {
                                   "Allocated": {
                                     "align": 8,
                                     "bytes": [
                                       0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      33,
                                       0,
                                       0,
                                       0,
@@ -2379,214 +2233,219 @@
                                       "ptrs": [
                                         [
                                           0,
-                                          1
+                                          0
                                         ]
                                       ]
                                     }
                                   }
                                 },
-                                "ty": 31
+                                "ty": 28
                               },
-                              "span": 32,
+                              "span": 73,
                               "user_ty": null
                             }
                           }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 15,
-                              "kind": "ZeroSized",
-                              "ty": 30
-                            },
-                            "span": 75,
-                            "user_ty": null
-                          }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
+                        }
+                      ]
                     },
-                    "span": 75
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 76,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 77,
-                  "ty": 32
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 68,
-                  "ty": 21
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 72,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 75,
-                  "ty": 33
-                }
-              ],
-              "span": 78,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "tup",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 77
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              "Tuple",
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 12,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            42,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 79,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 13,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            99,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 80,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 73
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 73
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
                     "span": 73
                   }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 29
+                          },
+                          "span": 68,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 68
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 28
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
+                          "projection": []
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            3
+                          ]
+                        ],
+                        "otherwise": 2
+                      }
+                    }
+                  },
+                  "span": 68
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 74
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 16,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    33,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        1
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 31
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 15,
+                            "kind": "ZeroSized",
+                            "ty": 30
+                          },
+                          "span": 75,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 75
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 76,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 77,
+                "ty": 32
+              },
+              {
+                "mutability": "Mut",
+                "span": 68,
+                "ty": 21
+              },
+              {
+                "mutability": "Mut",
+                "span": 72,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 75,
+                "ty": 33
+              }
+            ],
+            "span": 78,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "tup",
+                "source_info": {
+                  "scope": 1,
+                  "span": 77
                 },
-                {
-                  "mutability": "Mut",
-                  "span": 73,
-                  "ty": 32
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
+                  }
                 }
-              ],
-              "span": 73,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ]
+          },
           "id": 8,
           "name": "main"
         }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -98,316 +98,314 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 0,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 1,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              "Tuple",
-                              [
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 9,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            42,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 51,
-                                    "user_ty": null
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "const_": {
-                                      "id": 10,
-                                      "kind": {
-                                        "Allocated": {
-                                          "align": 4,
-                                          "bytes": [
-                                            99,
-                                            0,
-                                            0,
-                                            0
-                                          ],
-                                          "mutability": "Mut",
-                                          "provenance": {
-                                            "ptrs": []
-                                          }
-                                        }
-                                      },
-                                      "ty": 16
-                                    },
-                                    "span": 52,
-                                    "user_ty": null
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 53
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 3,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 54
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      1,
-                                      16
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 55
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 2,
-                            "projection": []
-                          },
-                          {
-                            "BinaryOp": [
-                              "Ne",
+          "body": {
+            "arg_count": 0,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 1,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            "Tuple",
+                            [
                               {
-                                "Move": {
-                                  "local": 3,
-                                  "projection": []
+                                "Constant": {
+                                  "const_": {
+                                    "id": 9,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          42,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 51,
+                                  "user_ty": null
                                 }
                               },
                               {
-                                "Move": {
-                                  "local": 4,
-                                  "projection": []
+                                "Constant": {
+                                  "const_": {
+                                    "id": 10,
+                                    "kind": {
+                                      "Allocated": {
+                                        "align": 4,
+                                        "bytes": [
+                                          99,
+                                          0,
+                                          0,
+                                          0
+                                        ],
+                                        "mutability": "Mut",
+                                        "provenance": {
+                                          "ptrs": []
+                                        }
+                                      }
+                                    },
+                                    "ty": 16
+                                  },
+                                  "span": 52,
+                                  "user_ty": null
                                 }
                               }
                             ]
-                          }
-                        ]
-                      },
-                      "span": 50
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "SwitchInt": {
-                        "discr": {
-                          "Move": {
-                            "local": 2,
-                            "projection": []
-                          }
-                        },
-                        "targets": {
-                          "branches": [
-                            [
-                              0,
-                              2
-                            ]
-                          ],
-                          "otherwise": 1
+                          ]
                         }
-                      }
+                      ]
+                    },
+                    "span": 53
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 54
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    1,
+                                    16
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 55
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 2,
+                          "projection": []
+                        },
+                        {
+                          "BinaryOp": [
+                            "Ne",
+                            {
+                              "Move": {
+                                "local": 3,
+                                "projection": []
+                              }
+                            },
+                            {
+                              "Move": {
+                                "local": 4,
+                                "projection": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     "span": 50
                   }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 56
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 12,
-                                "kind": {
-                                  "Allocated": {
-                                    "align": 8,
-                                    "bytes": [
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      32,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0,
-                                      0
-                                    ],
-                                    "mutability": "Mut",
-                                    "provenance": {
-                                      "ptrs": [
-                                        [
-                                          0,
-                                          0
-                                        ]
-                                      ]
-                                    }
-                                  }
-                                },
-                                "ty": 26
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
+                ],
+                "terminator": {
+                  "kind": {
+                    "SwitchInt": {
+                      "discr": {
+                        "Move": {
+                          "local": 2,
                           "projection": []
-                        },
-                        "func": {
+                        }
+                      },
+                      "targets": {
+                        "branches": [
+                          [
+                            0,
+                            2
+                          ]
+                        ],
+                        "otherwise": 1
+                      }
+                    }
+                  },
+                  "span": 50
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 56
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 11,
-                              "kind": "ZeroSized",
-                              "ty": 25
+                              "id": 12,
+                              "kind": {
+                                "Allocated": {
+                                  "align": 8,
+                                  "bytes": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    32,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                  ],
+                                  "mutability": "Mut",
+                                  "provenance": {
+                                    "ptrs": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "ty": 26
                             },
-                            "span": 57,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": null,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 57
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 58,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 59,
-                  "ty": 27
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 50,
-                  "ty": 28
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 54,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 55,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 57,
-                  "ty": 29
-                }
-              ],
-              "span": 60,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "tup",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 59
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 11,
+                            "kind": "ZeroSized",
+                            "ty": 25
+                          },
+                          "span": 57,
+                          "user_ty": null
+                        }
+                      },
+                      "target": null,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 57
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 58,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 59,
+                "ty": 27
+              },
+              {
+                "mutability": "Mut",
+                "span": 50,
+                "ty": 28
+              },
+              {
+                "mutability": "Mut",
+                "span": 54,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 55,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 57,
+                "ty": 29
+              }
+            ],
+            "span": 60,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "tup",
+                "source_info": {
+                  "scope": 1,
+                  "span": 59
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 6,
           "name": "main"
         }
@@ -418,356 +416,354 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 4,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 1
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 8
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 8,
-                            "projection": []
-                          },
-                          {
-                            "Aggregate": [
-                              {
-                                "Closure": [
-                                  1,
-                                  [
-                                    {
-                                      "Type": 1
-                                    },
-                                    {
-                                      "Type": 2
-                                    },
-                                    {
-                                      "Type": 3
-                                    },
-                                    {
-                                      "Type": 4
-                                    }
-                                  ]
-                                ]
-                              },
-                              [
-                                {
-                                  "Copy": {
-                                    "local": 1,
-                                    "projection": []
-                                  }
-                                }
-                              ]
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 3
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 7,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 8,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              {
-                                "PointerCoercion": "Unsize"
-                              },
-                              {
-                                "Copy": {
-                                  "local": 7,
-                                  "projection": []
-                                }
-                              },
-                              5
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 2
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 4,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 6,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 5,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 0,
-                              "kind": "ZeroSized",
-                              "ty": 0
-                            },
-                            "span": 0,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 5
                     },
                     "span": 1
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 5
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 6
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 5,
-                                "projection": [
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 8
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 8,
+                          "projection": []
+                        },
+                        {
+                          "Aggregate": [
+                            {
+                              "Closure": [
+                                1,
+                                [
                                   {
-                                    "Downcast": 0
+                                    "Type": 1
                                   },
                                   {
-                                    "Field": [
-                                      0,
-                                      6
-                                    ]
+                                    "Type": 2
+                                  },
+                                  {
+                                    "Type": 3
+                                  },
+                                  {
+                                    "Type": 4
                                   }
                                 ]
+                              ]
+                            },
+                            [
+                              {
+                                "Copy": {
+                                  "local": 1,
+                                  "projection": []
+                                }
                               }
+                            ]
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 3
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 7,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 8,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            {
+                              "PointerCoercion": "Unsize"
+                            },
+                            {
+                              "Copy": {
+                                "local": 7,
+                                "projection": []
+                              }
+                            },
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 2
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 6,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 5,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 0,
+                            "kind": "ZeroSized",
+                            "ty": 0
+                          },
+                          "span": 0,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 1
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 5
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 5,
+                              "projection": [
+                                {
+                                  "Downcast": 0
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    6
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 6
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "StorageDead": 8
-                      },
-                      "span": 7
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 7
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 4
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 8,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 9,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 10,
-                  "ty": 6
-                },
-                {
-                  "mutability": "Not",
-                  "span": 11,
-                  "ty": 8
-                },
-                {
-                  "mutability": "Not",
-                  "span": 12,
-                  "ty": 9
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 1,
-                  "ty": 10
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 2,
-                  "ty": 5
-                },
-                {
-                  "mutability": "Not",
-                  "span": 2,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Not",
-                  "span": 3,
-                  "ty": 12
-                }
-              ],
-              "span": 13,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 2,
-                  "composite": null,
-                  "name": "argc",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 10
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 3,
-                  "composite": null,
-                  "name": "argv",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 11
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 3,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 4,
-                  "composite": null,
-                  "name": "sigpipe",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 12
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 4,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "v",
-                  "source_info": {
-                    "scope": 1,
                     "span": 6
                   },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "StorageDead": 8
+                    },
+                    "span": 7
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 7
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 4
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 8,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 9,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 10,
+                "ty": 6
+              },
+              {
+                "mutability": "Not",
+                "span": 11,
+                "ty": 8
+              },
+              {
+                "mutability": "Not",
+                "span": 12,
+                "ty": 9
+              },
+              {
+                "mutability": "Mut",
+                "span": 1,
+                "ty": 10
+              },
+              {
+                "mutability": "Mut",
+                "span": 2,
+                "ty": 5
+              },
+              {
+                "mutability": "Not",
+                "span": 2,
+                "ty": 11
+              },
+              {
+                "mutability": "Not",
+                "span": 3,
+                "ty": 12
+              }
+            ],
+            "span": 13,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 2,
+                "composite": null,
+                "name": "argc",
+                "source_info": {
+                  "scope": 0,
+                  "span": 10
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 3,
+                "composite": null,
+                "name": "argv",
+                "source_info": {
+                  "scope": 0,
+                  "span": 11
+                },
+                "value": {
+                  "Place": {
+                    "local": 3,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 4,
+                "composite": null,
+                "name": "sigpipe",
+                "source_info": {
+                  "scope": 0,
+                  "span": 12
+                },
+                "value": {
+                  "Place": {
+                    "local": 4,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "v",
+                "source_info": {
+                  "scope": 1,
+                  "span": 6
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 0,
           "name": "std::rt::lang_start::<()>"
         }
@@ -778,359 +774,357 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageLive": 2
-                      },
-                      "span": 16
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 3
-                      },
-                      "span": 15
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 4
-                      },
-                      "span": 17
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 4,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 1,
-                                "projection": [
-                                  "Deref",
-                                  {
-                                    "Field": [
-                                      0,
-                                      7
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      "span": 17
-                    }
-                  ],
-                  "terminator": {
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
                     "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 4,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 3,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 1,
-                              "kind": "ZeroSized",
-                              "ty": 13
-                            },
-                            "span": 14,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 15
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 4
-                      },
-                      "span": 19
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 2,
-                              "kind": "ZeroSized",
-                              "ty": 14
-                            },
-                            "span": 18,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
+                      "StorageLive": 2
                     },
                     "span": 16
-                  }
-                },
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "StorageDead": 3
-                      },
-                      "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 3
                     },
-                    {
-                      "kind": {
-                        "StorageLive": 5
-                      },
-                      "span": 22
+                    "span": 15
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 4
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 5,
-                            "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              "Shared",
-                              {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 22
-                    },
-                    {
-                      "kind": {
-                        "StorageLive": 6
-                      },
-                      "span": 23
-                    },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 6,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Copy": {
-                                "local": 2,
-                                "projection": [
-                                  {
-                                    "Field": [
-                                      0,
-                                      15
-                                    ]
-                                  },
-                                  {
-                                    "Field": [
-                                      0,
-                                      9
-                                    ]
-                                  }
-                                ]
-                              }
+                    "span": 17
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 4,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 1,
+                              "projection": [
+                                "Deref",
+                                {
+                                  "Field": [
+                                    0,
+                                    7
+                                  ]
+                                }
+                              ]
                             }
                           }
-                        ]
-                      },
-                      "span": 23
+                        }
+                      ]
                     },
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Cast": [
-                              "IntToInt",
-                              {
-                                "Move": {
-                                  "local": 6,
-                                  "projection": []
-                                }
-                              },
-                              16
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 24
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 6
-                      },
-                      "span": 25
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 5
-                      },
-                      "span": 26
-                    },
-                    {
-                      "kind": {
-                        "StorageDead": 2
-                      },
-                      "span": 27
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 20
+                    "span": 17
                   }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 28,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 3,
-                  "ty": 11
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 16,
-                  "ty": 17
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 15,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 17,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 22,
-                  "ty": 18
-                },
-                {
-                  "mutability": "Mut",
-                  "span": 23,
-                  "ty": 9
-                }
-              ],
-              "span": 3,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "main",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 9
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": [
-                        "Deref",
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
                         {
-                          "Field": [
-                            0,
-                            7
+                          "Move": {
+                            "local": 4,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 3,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 1,
+                            "kind": "ZeroSized",
+                            "ty": 13
+                          },
+                          "span": 14,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 15
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 4
+                    },
+                    "span": 19
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 3,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 2,
+                            "kind": "ZeroSized",
+                            "ty": 14
+                          },
+                          "span": 18,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 16
+                }
+              },
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "StorageDead": 3
+                    },
+                    "span": 21
+                  },
+                  {
+                    "kind": {
+                      "StorageLive": 5
+                    },
+                    "span": 22
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 5,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            "Shared",
+                            {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                }
+                              ]
+                            }
                           ]
                         }
                       ]
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 29
+                    },
+                    "span": 22
                   },
-                  "value": {
-                    "Place": {
-                      "local": 2,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 30
+                  {
+                    "kind": {
+                      "StorageLive": 6
+                    },
+                    "span": 23
                   },
-                  "value": {
-                    "Place": {
-                      "local": 5,
-                      "projection": []
-                    }
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 6,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Copy": {
+                              "local": 2,
+                              "projection": [
+                                {
+                                  "Field": [
+                                    0,
+                                    15
+                                  ]
+                                },
+                                {
+                                  "Field": [
+                                    0,
+                                    9
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "span": 23
+                  },
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Cast": [
+                            "IntToInt",
+                            {
+                              "Move": {
+                                "local": 6,
+                                "projection": []
+                              }
+                            },
+                            16
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 24
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 6
+                    },
+                    "span": 25
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 5
+                    },
+                    "span": 26
+                  },
+                  {
+                    "kind": {
+                      "StorageDead": 2
+                    },
+                    "span": 27
+                  }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 20
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 28,
+                "ty": 16
+              },
+              {
+                "mutability": "Mut",
+                "span": 3,
+                "ty": 11
+              },
+              {
+                "mutability": "Mut",
+                "span": 16,
+                "ty": 17
+              },
+              {
+                "mutability": "Mut",
+                "span": 15,
+                "ty": 1
+              },
+              {
+                "mutability": "Mut",
+                "span": 17,
+                "ty": 7
+              },
+              {
+                "mutability": "Mut",
+                "span": 22,
+                "ty": 18
+              },
+              {
+                "mutability": "Mut",
+                "span": 23,
+                "ty": 9
+              }
+            ],
+            "span": 3,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "main",
+                "source_info": {
+                  "scope": 0,
+                  "span": 9
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": [
+                      "Deref",
+                      {
+                        "Field": [
+                          0,
+                          7
+                        ]
+                      }
+                    ]
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 1,
+                  "span": 29
+                },
+                "value": {
+                  "Place": {
+                    "local": 2,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 2,
+                  "span": 30
+                },
+                "value": {
+                  "Place": {
+                    "local": 5,
+                    "projection": []
+                  }
+                }
+              }
+            ]
+          },
           "id": 1,
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
@@ -1141,177 +1135,175 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": []
                           }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
                         },
-                        "func": {
+                        {
                           "Constant": {
                             "const_": {
-                              "id": 3,
+                              "id": 4,
                               "kind": "ZeroSized",
-                              "ty": 19
+                              "ty": 1
                             },
-                            "span": 31,
+                            "span": 32,
                             "user_ty": null
                           }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 33
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Constant": {
-                              "const_": {
-                                "id": 4,
-                                "kind": "ZeroSized",
-                                "ty": 1
-                              },
-                              "span": 32,
-                              "user_ty": null
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 2,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 5,
-                              "kind": "ZeroSized",
-                              "ty": 20
-                            },
-                            "span": 34,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 2,
-                        "unwind": "Unreachable"
-                      }
-                    },
-                    "span": 35
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 36
-                  }
-                }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 37,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 38,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 39,
-                  "ty": 1
-                }
-              ],
-              "span": 42,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "f",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 38
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 1,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": null,
-                  "composite": null,
-                  "name": "result",
-                  "source_info": {
-                    "scope": 1,
-                    "span": 40
-                  },
-                  "value": {
-                    "Place": {
-                      "local": 0,
-                      "projection": []
-                    }
-                  }
-                },
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "dummy",
-                  "source_info": {
-                    "scope": 2,
-                    "span": 41
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
                       },
-                      "span": 32,
-                      "user_ty": null
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 3,
+                            "kind": "ZeroSized",
+                            "ty": 19
+                          },
+                          "span": 31,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
                     }
+                  },
+                  "span": 33
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Constant": {
+                            "const_": {
+                              "id": 4,
+                              "kind": "ZeroSized",
+                              "ty": 1
+                            },
+                            "span": 32,
+                            "user_ty": null
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 2,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 5,
+                            "kind": "ZeroSized",
+                            "ty": 20
+                          },
+                          "span": 34,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 2,
+                      "unwind": "Unreachable"
+                    }
+                  },
+                  "span": 35
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 36
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 37,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 38,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 39,
+                "ty": 1
+              }
+            ],
+            "span": 42,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "f",
+                "source_info": {
+                  "scope": 0,
+                  "span": 38
+                },
+                "value": {
+                  "Place": {
+                    "local": 1,
+                    "projection": []
                   }
                 }
-              ]
-            }
-          ],
+              },
+              {
+                "argument_index": null,
+                "composite": null,
+                "name": "result",
+                "source_info": {
+                  "scope": 1,
+                  "span": 40
+                },
+                "value": {
+                  "Place": {
+                    "local": 0,
+                    "projection": []
+                  }
+                }
+              },
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "dummy",
+                "source_info": {
+                  "scope": 2,
+                  "span": 41
+                },
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
+                  }
+                }
+              }
+            ]
+          },
           "id": 2,
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
@@ -1322,83 +1314,81 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 1,
-                              "projection": [
-                                "Deref"
-                              ]
-                            }
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
+                            "local": 1,
+                            "projection": [
+                              "Deref"
+                            ]
+                          }
+                        },
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
+                        }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 6,
+                            "kind": "ZeroSized",
+                            "ty": 21
                           },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 6,
-                              "kind": "ZeroSized",
-                              "ty": 21
-                            },
-                            "span": 43,
-                            "user_ty": null
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 22
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 22
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1409,63 +1399,61 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [],
-                        "destination": {
-                          "local": 0,
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
                           "projection": []
-                        },
-                        "func": {
-                          "Move": {
-                            "local": 1,
-                            "projection": []
-                          }
-                        },
-                        "target": 1,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 7
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
@@ -1476,155 +1464,153 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 2,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 3,
+                          "projection": []
+                        },
+                        {
+                          "Ref": [
+                            {
+                              "kind": "ReErased"
+                            },
+                            {
+                              "Mut": {
+                                "kind": "Default"
+                              }
+                            },
+                            {
+                              "local": 1,
+                              "projection": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "span": 43
+                  }
+                ],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [
+                        {
+                          "Move": {
                             "local": 3,
                             "projection": []
-                          },
-                          {
-                            "Ref": [
-                              {
-                                "kind": "ReErased"
-                              },
-                              {
-                                "Mut": {
-                                  "kind": "Default"
-                                }
-                              },
-                              {
-                                "local": 1,
-                                "projection": []
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "span": 43
-                    }
-                  ],
-                  "terminator": {
-                    "kind": {
-                      "Call": {
-                        "args": [
-                          {
-                            "Move": {
-                              "local": 3,
-                              "projection": []
-                            }
-                          },
-                          {
-                            "Move": {
-                              "local": 2,
-                              "projection": []
-                            }
-                          }
-                        ],
-                        "destination": {
-                          "local": 0,
-                          "projection": []
-                        },
-                        "func": {
-                          "Constant": {
-                            "const_": {
-                              "id": 7,
-                              "kind": "ZeroSized",
-                              "ty": 23
-                            },
-                            "span": 43,
-                            "user_ty": null
                           }
                         },
-                        "target": 1,
-                        "unwind": {
-                          "Cleanup": 3
+                        {
+                          "Move": {
+                            "local": 2,
+                            "projection": []
+                          }
                         }
+                      ],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Constant": {
+                          "const_": {
+                            "id": 7,
+                            "kind": "ZeroSized",
+                            "ty": 23
+                          },
+                          "span": 43,
+                          "user_ty": null
+                        }
+                      },
+                      "target": 1,
+                      "unwind": {
+                        "Cleanup": 3
                       }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 2,
-                        "unwind": "Continue"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": {
-                      "Drop": {
-                        "place": {
-                          "local": 1,
-                          "projection": []
-                        },
-                        "target": 4,
-                        "unwind": "Terminate"
-                      }
-                    },
-                    "span": 43
-                  }
-                },
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Resume",
-                    "span": 43
-                  }
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 43,
-                  "ty": 16
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 12
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 43,
-                  "ty": 24
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 2,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
                 }
-              ],
-              "span": 43,
-              "spread_arg": 2,
-              "var_debug_info": []
-            }
-          ],
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Drop": {
+                      "place": {
+                        "local": 1,
+                        "projection": []
+                      },
+                      "target": 4,
+                      "unwind": "Terminate"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Resume",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 16
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 24
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
@@ -1635,35 +1621,33 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 44
-                  }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 44
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 44,
-                  "ty": 1
-                },
-                {
-                  "mutability": "Not",
-                  "span": 44,
-                  "ty": 22
-                }
-              ],
-              "span": 44,
-              "spread_arg": null,
-              "var_debug_info": []
-            }
-          ],
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 44,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 44,
+                "ty": 22
+              }
+            ],
+            "span": 44,
+            "spread_arg": null,
+            "var_debug_info": []
+          },
           "id": 4,
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
@@ -1674,92 +1658,90 @@
       "details": null,
       "mono_item_kind": {
         "MonoItemFn": {
-          "body": [
-            {
-              "arg_count": 1,
-              "blocks": [
-                {
-                  "statements": [
-                    {
-                      "kind": {
-                        "Assign": [
-                          {
-                            "local": 0,
-                            "projection": []
-                          },
-                          {
-                            "Use": {
-                              "Constant": {
-                                "const_": {
-                                  "id": 8,
-                                  "kind": {
-                                    "Allocated": {
-                                      "align": 1,
-                                      "bytes": [
-                                        0
-                                      ],
-                                      "mutability": "Mut",
-                                      "provenance": {
-                                        "ptrs": []
-                                      }
+          "body": {
+            "arg_count": 1,
+            "blocks": [
+              {
+                "statements": [
+                  {
+                    "kind": {
+                      "Assign": [
+                        {
+                          "local": 0,
+                          "projection": []
+                        },
+                        {
+                          "Use": {
+                            "Constant": {
+                              "const_": {
+                                "id": 8,
+                                "kind": {
+                                  "Allocated": {
+                                    "align": 1,
+                                    "bytes": [
+                                      0
+                                    ],
+                                    "mutability": "Mut",
+                                    "provenance": {
+                                      "ptrs": []
                                     }
-                                  },
-                                  "ty": 17
+                                  }
                                 },
-                                "span": 46,
-                                "user_ty": null
-                              }
+                                "ty": 17
+                              },
+                              "span": 46,
+                              "user_ty": null
                             }
                           }
-                        ]
-                      },
-                      "span": 46
-                    }
-                  ],
-                  "terminator": {
-                    "kind": "Return",
-                    "span": 45
+                        }
+                      ]
+                    },
+                    "span": 46
                   }
+                ],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 45
                 }
-              ],
-              "locals": [
-                {
-                  "mutability": "Mut",
-                  "span": 47,
-                  "ty": 17
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 47,
+                "ty": 17
+              },
+              {
+                "mutability": "Not",
+                "span": 48,
+                "ty": 1
+              }
+            ],
+            "span": 49,
+            "spread_arg": null,
+            "var_debug_info": [
+              {
+                "argument_index": 1,
+                "composite": null,
+                "name": "self",
+                "source_info": {
+                  "scope": 0,
+                  "span": 48
                 },
-                {
-                  "mutability": "Not",
-                  "span": 48,
-                  "ty": 1
-                }
-              ],
-              "span": 49,
-              "spread_arg": null,
-              "var_debug_info": [
-                {
-                  "argument_index": 1,
-                  "composite": null,
-                  "name": "self",
-                  "source_info": {
-                    "scope": 0,
-                    "span": 48
-                  },
-                  "value": {
-                    "Const": {
-                      "const_": {
-                        "id": 4,
-                        "kind": "ZeroSized",
-                        "ty": 1
-                      },
-                      "span": 32,
-                      "user_ty": null
-                    }
+                "value": {
+                  "Const": {
+                    "const_": {
+                      "id": 4,
+                      "kind": "ZeroSized",
+                      "ty": 1
+                    },
+                    "span": 32,
+                    "user_ty": null
                   }
                 }
-              ]
-            }
-          ],
+              }
+            ]
+          },
           "id": 5,
           "name": "<() as std::process::Termination>::report"
         }


### PR DESCRIPTION
Stable MIR `Instance` `Body` has already allocated promoted, [see this conversation on zulip]([#project-stable-mir > Getting fully monomorphised &#96;MonoItem&#96;s @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/320896-project-stable-mir/topic/Getting.20fully.20monomorphised.20.60MonoItem.60s/near/507085029))