### PR TITLE
Extract discriminant information

### DIFF
--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -409,9 +409,9 @@ fn decorate(thing: String, p: &ProjectionElem) -> String {
                 to
             )
         }
-        ProjectionElem::Downcast(i) => format!("{thing} as {:?}", i),
-        ProjectionElem::OpaqueCast(ty) => format!("{thing} as type {}", ty),
-        ProjectionElem::Subtype(i) => format!("{thing} as {:?}", i),
+        ProjectionElem::Downcast(i) => format!("({thing} as variant {})", i.to_index()),
+        ProjectionElem::OpaqueCast(ty) => format!("{thing} as type {ty}"),
+        ProjectionElem::Subtype(i) => format!("{thing} :> {i}"),
     }
 }
 
@@ -421,7 +421,7 @@ impl GraphLabelString for AggregateKind {
         match &self {
             Array(_ty) => "Array".to_string(),
             Tuple {} => "Tuple".to_string(),
-            Adt(_, _, _, _, _) => "Adt".to_string(), // (AdtDef, VariantIdx, GenericArgs, Option<usize>, Option<FieldIdx>),
+            Adt(_, idx, _, _, _) => format!("Adt{{{}}}", idx.to_index()), // (AdtDef, VariantIdx, GenericArgs, Option<usize>, Option<FieldIdx>),
             Closure(_, _) => "Closure".to_string(),  // (ClosureDef, GenericArgs),
             Coroutine(_, _, _) => "Coroutine".to_string(), // (CoroutineDef, GenericArgs, Movability),
             // CoroutineClosure{} => "CoroutineClosure".to_string(), // (CoroutineClosureDef, GenericArgs),

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -422,7 +422,7 @@ impl GraphLabelString for AggregateKind {
             Array(_ty) => "Array".to_string(),
             Tuple {} => "Tuple".to_string(),
             Adt(_, idx, _, _, _) => format!("Adt{{{}}}", idx.to_index()), // (AdtDef, VariantIdx, GenericArgs, Option<usize>, Option<FieldIdx>),
-            Closure(_, _) => "Closure".to_string(),  // (ClosureDef, GenericArgs),
+            Closure(_, _) => "Closure".to_string(), // (ClosureDef, GenericArgs),
             Coroutine(_, _, _) => "Coroutine".to_string(), // (CoroutineDef, GenericArgs, Movability),
             // CoroutineClosure{} => "CoroutineClosure".to_string(), // (CoroutineClosureDef, GenericArgs),
             RawPtr(ty, Mutability::Mut) => format!("*mut ({})", ty),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -13,9 +13,7 @@ extern crate stable_mir;
 extern crate serde;
 extern crate serde_json;
 use rustc_middle as middle;
-use rustc_middle::ty::{
-    EarlyBinder, FnSig, GenericArgs, Ty, TyCtxt, TyKind, TypeFoldable, TypingEnv,
-};
+use rustc_middle::ty::{EarlyBinder, FnSig, GenericArgs, Ty, TyCtxt, TypeFoldable, TypingEnv};
 use rustc_session::config::{OutFileName, OutputType};
 use rustc_smir::rustc_internal;
 use rustc_span::{
@@ -26,7 +24,7 @@ use serde::{Serialize, Serializer};
 use stable_mir::{
     mir::mono::{Instance, InstanceKind, MonoItem},
     mir::{alloc::AllocId, visit::MirVisitor, Body, LocalDecl, Rvalue, Terminator, TerminatorKind},
-    ty::{Allocation, ConstDef, ForeignItemKind},
+    ty::{Allocation, ConstDef, ForeignItemKind, RigidTy, TyKind, VariantIdx},
     CrateDef, CrateItem, ItemKind,
 };
 
@@ -100,8 +98,8 @@ where
 
 fn print_type<'tcx>(tcx: TyCtxt<'tcx>, id: DefId, ty: EarlyBinder<'tcx, Ty<'tcx>>) -> String {
     // lookup type kind in order to perform case analysis
-    let kind: &TyKind = ty.skip_binder().kind();
-    if let TyKind::FnDef(fun_id, args) = kind {
+    let kind: &middle::ty::TyKind = ty.skip_binder().kind();
+    if let middle::ty::TyKind::FnDef(fun_id, args) = kind {
         // since FnDef doesn't contain signature, lookup actual function type
         // via getting fn signature with parameters and resolving those parameters
         let sig0 = tcx.fn_sig(fun_id);
@@ -909,6 +907,56 @@ fn collect_items(tcx: TyCtxt<'_>) -> HashMap<String, Item> {
         .collect::<HashMap<_, _>>()
 }
 
+// Type metadata required for execution
+
+#[derive(Serialize)]
+pub enum TypeMetadata {
+    Basetype(RigidTy),
+    EnumType {
+        name: String,
+        discriminants: Vec<(VariantIdx, u128)>,
+    },
+    StructType {
+        name: String,
+    },
+}
+
+fn mk_type_metadata(
+    tcx: TyCtxt<'_>,
+    k: stable_mir::ty::Ty,
+    t: TyKind,
+) -> Option<(stable_mir::ty::Ty, TypeMetadata)> {
+    use TypeMetadata::*;
+    match t {
+        TyKind::RigidTy(basetype) if t.is_primitive() => Some((k, Basetype(basetype))),
+        // for enums, we need a mapping of variantIdx to discriminant
+        // this requires access to the internals and is not provided as an interface function at the moment
+        TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_enum() => {
+            let adt_internal = rustc_internal::internal(tcx, adt_def);
+            let discriminants = adt_internal
+                .discriminants(tcx)
+                .map(|(v_idx, discr)| (rustc_internal::stable(v_idx), discr.val))
+                .collect::<Vec<_>>();
+            let adt_binder = tcx.type_of(adt_internal.did()).skip_binder();
+            let name = format!("{adt_binder:#?}");
+            Some((
+                k,
+                EnumType {
+                    name,
+                    discriminants,
+                },
+            ))
+        }
+        // for structs, we record the name for information purposes
+        TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_struct() => {
+            let adt_internal = rustc_internal::internal(tcx, adt_def);
+            let name = format!("{:#?}", tcx.type_of(adt_internal.did()).skip_binder());
+            Some((k, StructType { name }))
+        }
+        _ => None,
+    }
+}
+
 /// the serialised data structure as a whole
 #[derive(Serialize)]
 pub struct SmirJson<'t> {
@@ -918,7 +966,7 @@ pub struct SmirJson<'t> {
     pub functions: Vec<(LinkMapKey<'t>, FnSymType)>,
     pub uneval_consts: Vec<(ConstDef, String)>,
     pub items: Vec<Item>,
-    pub types: Vec<(stable_mir::ty::Ty, stable_mir::ty::TyKind)>,
+    pub types: Vec<(stable_mir::ty::Ty, TypeMetadata)>,
     pub debug: Option<SmirJsonDebugInfo<'t>>,
 }
 
@@ -981,7 +1029,8 @@ pub fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
     let types = visited_tys
         .into_iter()
         .map(|(k, (v, _))| (k, v))
-        .filter(|(_, v)| v.is_primitive())
+        .filter_map(|(k, t)| mk_type_metadata(tcx, k, t))
+        //        .filter(|(_, v)| v.is_primitive())
         .collect::<Vec<_>>();
 
     SmirJson {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -282,12 +282,16 @@ pub struct Item {
 }
 
 impl PartialEq for Item {
-    fn eq(&self, other: &Item) -> bool { self.mono_item.eq(&other.mono_item) }
+    fn eq(&self, other: &Item) -> bool {
+        self.mono_item.eq(&other.mono_item)
+    }
 }
 impl Eq for Item {}
 
 impl PartialOrd for Item {
-    fn partial_cmp(&self, other: &Item) -> Option<std::cmp::Ordering> { Some(self.cmp(other)) }
+    fn partial_cmp(&self, other: &Item) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Ord for Item {
@@ -298,13 +302,21 @@ impl Ord for Item {
                 "{}!{}",
                 i.symbol_name,
                 match &i.mono_item_kind {
-                    MonoItemFn{name, id: _, body: _} => name,
-                    MonoItemStatic{name, id: _, allocation: _} => name,
-                    MonoItemGlobalAsm{asm} => asm,
+                    MonoItemFn {
+                        name,
+                        id: _,
+                        body: _,
+                    } => name,
+                    MonoItemStatic {
+                        name,
+                        id: _,
+                        allocation: _,
+                    } => name,
+                    MonoItemGlobalAsm { asm } => asm,
                 }
             )
         };
-        sort_key(&self).cmp(&sort_key(&other))
+        sort_key(self).cmp(&sort_key(other))
     }
 }
 
@@ -1062,9 +1074,9 @@ pub fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
 
     // sort output vectors to stabilise output (a bit)
     allocs.sort_by(|a, b| a.0.to_index().cmp(&b.0.to_index()));
-    functions.sort_by(|a, b| a.0.0.to_index().cmp(&b.0.0.to_index()));
+    functions.sort_by(|a, b| a.0 .0.to_index().cmp(&b.0 .0.to_index()));
     items.sort();
-    types.sort_by(|a,b| a.0.to_index().cmp(&b.0.to_index()));
+    types.sort_by(|a, b| a.0.to_index().cmp(&b.0.to_index()));
 
     SmirJson {
         name: local_crate.name,

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -5,24 +5,20 @@
 # Apply the normalisation filter
 { allocs:
     ( [ .allocs[] ]
-# sort allocs by their ID
-        | sort_by(.[0])
+# delete unstable alloc ID
         | map(del(.[0]))
     ),
   functions:
     ( [ .functions[] ]
-# sort functions by their ID (int, first in list)
-        | sort_by(.[0])
+# delete unstable function ID
         | map(del(.[0]))
     ),
   items:
     ( [ .items[] ]
-# sort items by symbol name they refer to and by the function name for functions
-        | sort_by(.symbol_name, .mono_item_kind.MonoItemFn.name)
     ),
   types:
     ( [ .types[] ]
-# sort types by their ID (int, first in list)
-        | sort_by(.[0])
+# delete unstable Ty ID (int, first in list)
+        | map(del(.[0]))
     )
 }

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -1725,71 +1725,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 73
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 73
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 73,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 73,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 73,
-                "ty": 1
-              }
-            ],
-            "span": 73,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 5,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1935,6 +1870,71 @@
           },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 73
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 73
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 73,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 73,
+                "ty": 1
+              }
+            ],
+            "span": 73,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 5,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -3120,49 +3120,150 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }
     ],
     [
-      40,
       {
-        "RigidTy": "Bool"
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ],
+            [
+              2,
+              2
+            ]
+          ],
+          "name": "core::panicking::AssertKind"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option<T/#0>"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::fmt::Arguments<'a/#0>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::fmt::Error"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::fmt::Formatter<'a/#0>"
+        }
       }
     ]
   ]

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -2148,71 +2148,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -2358,6 +2293,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -9713,48 +9713,80 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      28,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::panic::Location<'a/#0>"
         }
       }
     ]

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1639,41 +1639,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Char"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Char"
       }
     ]
   ]

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1582,71 +1582,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1801,6 +1736,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -1930,41 +1930,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      32,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1402,71 +1402,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1621,6 +1556,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -1750,41 +1750,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      29,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1893,47 +1893,72 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "Usize"
         }
       }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -1658,71 +1658,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1877,6 +1812,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -2006,41 +2006,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      27,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1757,34 +1757,61 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
       }
     ]

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1034,71 +1034,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1244,6 +1179,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -1461,34 +1461,78 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "Letter"
         }
       }
     ]

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -1084,71 +1084,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1294,6 +1229,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -2311,47 +2311,72 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -1126,71 +1126,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1336,6 +1271,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -2209,57 +2209,81 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Float": "F32"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": {
           "Float": "F64"
         }
       }
     ],
     [
-      29,
       {
-        "RigidTy": "Bool"
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -1083,71 +1083,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1293,6 +1228,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -2004,41 +2004,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      27,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2262,47 +2262,72 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1795,42 +1795,85 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option<T/#0>"
         }
       }
     ]

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1521,71 +1521,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1740,6 +1675,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -1869,47 +1869,72 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -1723,71 +1723,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1942,6 +1877,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -2071,47 +2071,72 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2071,49 +2071,74 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": "Bool"
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1078,71 +1078,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1288,6 +1223,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -1703,34 +1703,61 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
       }
     ]

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -1346,71 +1346,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1556,6 +1491,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -3483,73 +3483,102 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I16"
         }
       }
     ],
     [
-      29,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I64"
         }
       }
     ],
     [
-      30,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I128"
         }
       }
     ],
     [
-      31,
       {
-        "RigidTy": "Bool"
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::panic::Location<'a/#0>"
+        }
       }
     ]
   ]

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -2041,71 +2041,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 85
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 85
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 85,
-                "ty": 12
-              },
-              {
-                "mutability": "Not",
-                "span": 85,
-                "ty": 18
-              },
-              {
-                "mutability": "Not",
-                "span": 85,
-                "ty": 12
-              }
-            ],
-            "span": 85,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 5,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -2251,6 +2186,71 @@
           },
           "id": 5,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 85
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 85
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 85,
+                "ty": 12
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 18
+              },
+              {
+                "mutability": "Not",
+                "span": 85,
+                "ty": 12
+              }
+            ],
+            "span": 85,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 5,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -4485,48 +4485,138 @@
   ],
   "types": [
     [
-      0,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "Usize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::ops::Range<Idx/#0>"
+        }
       }
     ],
     [
-      13,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option<T/#0>"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      17,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      20,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      27,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::array::TryFromSliceError"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option<T/#0>"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
         }
       }
     ]

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1760,34 +1760,61 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
       }
     ]

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1085,71 +1085,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1295,6 +1230,71 @@
           },
           "id": 3,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -1905,48 +1905,80 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
       }
     ],
     [
-      26,
       {
-        "RigidTy": {
+        "Basetype": "Bool"
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "St"
         }
       }
     ]

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2498,49 +2498,74 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      25,
       {
-        "RigidTy": {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Uint": "Usize"
         }
       }
     ],
     [
-      26,
       {
-        "RigidTy": "Bool"
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -1295,71 +1295,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 52
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 52
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 52,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 52,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 52,
-                "ty": 1
-              }
-            ],
-            "span": 52,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 4,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1505,6 +1440,71 @@
           },
           "id": 4,
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 52
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 52
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 52,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 52,
+                "ty": 1
+              }
+            ],
+            "span": 52,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 4,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
@@ -2455,41 +2455,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      21,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
       }
     ]
   ]

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1403,71 +1403,6 @@
             "arg_count": 2,
             "blocks": [
               {
-                "statements": [],
-                "terminator": {
-                  "kind": {
-                    "Call": {
-                      "args": [],
-                      "destination": {
-                        "local": 0,
-                        "projection": []
-                      },
-                      "func": {
-                        "Move": {
-                          "local": 1,
-                          "projection": []
-                        }
-                      },
-                      "target": 1,
-                      "unwind": "Continue"
-                    }
-                  },
-                  "span": 43
-                }
-              },
-              {
-                "statements": [],
-                "terminator": {
-                  "kind": "Return",
-                  "span": 43
-                }
-              }
-            ],
-            "locals": [
-              {
-                "mutability": "Mut",
-                "span": 43,
-                "ty": 1
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 7
-              },
-              {
-                "mutability": "Not",
-                "span": 43,
-                "ty": 1
-              }
-            ],
-            "span": 43,
-            "spread_arg": 2,
-            "var_debug_info": []
-          },
-          "id": 3,
-          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
-        }
-      },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
-    },
-    {
-      "details": null,
-      "mono_item_kind": {
-        "MonoItemFn": {
-          "body": {
-            "arg_count": 2,
-            "blocks": [
-              {
                 "statements": [
                   {
                     "kind": {
@@ -1622,6 +1557,71 @@
       "mono_item_kind": {
         "MonoItemFn": {
           "body": {
+            "arg_count": 2,
+            "blocks": [
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": {
+                    "Call": {
+                      "args": [],
+                      "destination": {
+                        "local": 0,
+                        "projection": []
+                      },
+                      "func": {
+                        "Move": {
+                          "local": 1,
+                          "projection": []
+                        }
+                      },
+                      "target": 1,
+                      "unwind": "Continue"
+                    }
+                  },
+                  "span": 43
+                }
+              },
+              {
+                "statements": [],
+                "terminator": {
+                  "kind": "Return",
+                  "span": 43
+                }
+              }
+            ],
+            "locals": [
+              {
+                "mutability": "Mut",
+                "span": 43,
+                "ty": 1
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 7
+              },
+              {
+                "mutability": "Not",
+                "span": 43,
+                "ty": 1
+              }
+            ],
+            "span": 43,
+            "spread_arg": 2,
+            "var_debug_info": []
+          },
+          "id": 3,
+          "name": "<fn() as std::ops::FnOnce<()>>::call_once"
+        }
+      },
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
+    },
+    {
+      "details": null,
+      "mono_item_kind": {
+        "MonoItemFn": {
+          "body": {
             "arg_count": 1,
             "blocks": [
               {
@@ -1751,41 +1751,67 @@
   ],
   "types": [
     [
-      2,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "I8"
         }
       }
     ],
     [
-      6,
       {
-        "RigidTy": {
+        "Basetype": {
           "Int": "Isize"
         }
       }
     ],
     [
-      9,
       {
-        "RigidTy": {
+        "Basetype": {
           "Uint": "U8"
         }
       }
     ],
     [
-      16,
       {
-        "RigidTy": {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result<T/#0, E/#1>"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": {
           "Int": "I32"
         }
       }
     ],
     [
-      28,
       {
-        "RigidTy": "Bool"
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "Basetype": "Bool"
       }
     ]
   ]


### PR DESCRIPTION
As it turns out, the `SwitchInt` terminator uses `discriminants` (computed using `RValue::Discriminant` ) but when an enum value is created we only have the `VariantIdx` (`0..n` in source order, including uninhabited variants).

This PR extracts a mapping of `VariantIdx` to discriminants (bytes stored as `u128`) as type metadata for each `enum`  that can be used in the semantics to implement the `RValue::Discriminant`.
