### PR TITLE
Add adt_def to struct and enum metadata

### DIFF
--- a/panic_example.rs
+++ b/panic_example.rs
@@ -1,1 +1,0 @@
-tests/integration/failing/panic_example.rs

--- a/panic_example.smir.json
+++ b/panic_example.smir.json
@@ -1,1 +1,0 @@
-tests/integration/failing/panic_example.smir.json.expected

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -24,7 +24,7 @@ use serde::{Serialize, Serializer};
 use stable_mir::{
     mir::mono::{Instance, InstanceKind, MonoItem},
     mir::{alloc::AllocId, visit::MirVisitor, Body, LocalDecl, Rvalue, Terminator, TerminatorKind},
-    ty::{Allocation, ConstDef, ForeignItemKind, IndexedVal, RigidTy, TyKind, VariantIdx},
+    ty::{AdtDef, Allocation, ConstDef, ForeignItemKind, IndexedVal, RigidTy, TyKind, VariantIdx},
     CrateDef, CrateItem, ItemKind,
 };
 
@@ -953,10 +953,12 @@ pub enum TypeMetadata {
     PrimitiveType(RigidTy),
     EnumType {
         name: String,
+        adt_def: AdtDef,
         discriminants: Vec<(VariantIdx, u128)>,
     },
     StructType {
         name: String,
+        adt_def: AdtDef,
     },
 }
 
@@ -982,6 +984,7 @@ fn mk_type_metadata(
                 k,
                 EnumType {
                     name,
+                    adt_def,
                     discriminants,
                 },
             ))
@@ -990,7 +993,7 @@ fn mk_type_metadata(
         TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_struct() => {
             let adt_internal = rustc_internal::internal(tcx, adt_def);
             let name = format!("{:#?}", tcx.type_of(adt_internal.did()).skip_binder());
-            Some((k, StructType { name }))
+            Some((k, StructType { name, adt_def }))
         }
         _ => None,
     }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -20,5 +20,8 @@
     ( [ .types[] ]
 # delete unstable Ty ID (int, first in list)
         | map(del(.[0]))
+# delete unstable adt_def from Struct and Enum
+        | map(del(.[0].StructType.adt_def))
+        | map(del(.[0].EnumType.adt_def))
     )
 }


### PR DESCRIPTION
These `adt_def`  of `struct` and `enum` metadata are required for a reverse mapping `adt_def -> Ty` in the semantics. 
The `AggregateKind` only carries the `adt_def` but we have to look up the discriminant information (and potentially other metadata later) from a `Ty` key.

Note that the `adt_def` is unstable, it changes with every compiler run, so we delete the field in the golden tests.