### PR TITLE
Updates: Graph and `Adt` names

### DIFF
--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -223,7 +223,9 @@ impl SmirJson<'_> {
 
                         if let Some(body) = &body {
                             process_blocks(&mut c, 0, &body.blocks);
-                        } // TODO: Investigate `MonoItem::Fn` without `Body` and make dummy node if correct
+                        } else {
+                            c.node_auto().set_label("<empty body>");
+                        }
 
                         drop(c); // so we can borrow graph again
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -978,8 +978,7 @@ fn mk_type_metadata(
                 .discriminants(tcx)
                 .map(|(v_idx, discr)| (rustc_internal::stable(v_idx), discr.val))
                 .collect::<Vec<_>>();
-            let adt_binder = tcx.type_of(adt_internal.did()).skip_binder();
-            let name = format!("{adt_binder:#?}");
+            let name = adt_def.name();
             Some((
                 k,
                 EnumType {
@@ -991,8 +990,7 @@ fn mk_type_metadata(
         }
         // for structs, we record the name for information purposes
         TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_struct() => {
-            let adt_internal = rustc_internal::internal(tcx, adt_def);
-            let name = format!("{:#?}", tcx.type_of(adt_internal.did()).skip_binder());
+            let name = adt_def.name();
             Some((k, StructType { name, adt_def }))
         }
         _ => None,

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3153,7 +3153,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -3191,7 +3191,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -3236,7 +3236,7 @@
               1
             ]
           ],
-          "name": "std::option::Option<T/#0>"
+          "name": "std::option::Option"
         }
       }
     ],
@@ -3248,7 +3248,7 @@
     [
       {
         "StructType": {
-          "name": "std::fmt::Arguments<'a/#0>"
+          "name": "std::fmt::Arguments"
         }
       }
     ],
@@ -3262,7 +3262,7 @@
     [
       {
         "StructType": {
-          "name": "std::fmt::Formatter<'a/#0>"
+          "name": "std::fmt::Formatter"
         }
       }
     ]

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9746,7 +9746,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -9786,7 +9786,7 @@
     [
       {
         "StructType": {
-          "name": "std::panic::Location<'a/#0>"
+          "name": "std::panic::Location"
         }
       }
     ]

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1672,7 +1672,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1963,7 +1963,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1783,7 +1783,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1926,7 +1926,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2039,7 +2039,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1790,7 +1790,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1494,7 +1494,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2344,7 +2344,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2242,7 +2242,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2037,7 +2037,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2295,7 +2295,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1828,7 +1828,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -1873,7 +1873,7 @@
               1
             ]
           ],
-          "name": "std::option::Option<T/#0>"
+          "name": "std::option::Option"
         }
       }
     ]

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1902,7 +1902,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2104,7 +2104,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2104,7 +2104,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1736,7 +1736,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3516,7 +3516,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -3577,7 +3577,7 @@
     [
       {
         "StructType": {
-          "name": "std::panic::Location<'a/#0>"
+          "name": "std::panic::Location"
         }
       }
     ]

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4494,7 +4494,7 @@
     [
       {
         "StructType": {
-          "name": "std::ops::Range<Idx/#0>"
+          "name": "std::ops::Range"
         }
       }
     ],
@@ -4511,7 +4511,7 @@
               1
             ]
           ],
-          "name": "std::option::Option<T/#0>"
+          "name": "std::option::Option"
         }
       }
     ],
@@ -4554,7 +4554,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],
@@ -4599,7 +4599,7 @@
               1
             ]
           ],
-          "name": "std::option::Option<T/#0>"
+          "name": "std::option::Option"
         }
       }
     ],
@@ -4616,7 +4616,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ]

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1793,7 +1793,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1938,7 +1938,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2531,7 +2531,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2488,7 +2488,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1784,7 +1784,7 @@
               1
             ]
           ],
-          "name": "std::result::Result<T/#0, E/#1>"
+          "name": "std::result::Result"
         }
       }
     ],


### PR DESCRIPTION
- I removed rendering an empty node for the graph if the `MonoItem::Fn` has no `Body`, I have not had time to dig much more into it but the graph should have the empty node replaced. 

- Accessing the name for `Adt` is not done with the `Stable MIR` API, updating to doing this means the names are slightly different (as can be seen in the diff) but I don't think the information using the internal method has anything needed