### PR TITLE
More type metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: 'Run smir integration tests'
         run: |
+          which jq
+          jq --version
           make integration-test
 
   ui-tests:

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -976,9 +976,9 @@ fn mk_type_metadata(
     k: stable_mir::ty::Ty,
     t: TyKind,
 ) -> Option<(stable_mir::ty::Ty, TypeMetadata)> {
-    use TypeMetadata::*;
     use stable_mir::ty::RigidTy::*;
     use TyKind::RigidTy as T;
+    use TypeMetadata::*;
     match t {
         T(prim_type) if t.is_primitive() => Some((k, PrimitiveType(prim_type))),
         // for enums, we need a mapping of variantIdx to discriminant
@@ -1010,26 +1010,23 @@ fn mk_type_metadata(
             Some((k, UnionType { name, adt_def }))
         }
         // encode str together with primitive types
-        T(Str) =>
-            Some((k, PrimitiveType(Str))),
+        T(Str) => Some((k, PrimitiveType(Str))),
         // for arrays and slices, record element type and optional size
-        T(Array(ty, ty_const)) =>
-            Some((k, ArrayType(ty, Some(ty_const)))),
-        T(Slice(ty)) =>
-            Some((k, ArrayType(ty, None))),
+        T(Array(ty, ty_const)) => Some((k, ArrayType(ty, Some(ty_const)))),
+        T(Slice(ty)) => Some((k, ArrayType(ty, None))),
         // for raw pointers and references store the pointee type
-        T(RawPtr(ty, _)) =>
-            Some((k, PtrType(ty))),
-        T(Ref(_, ty, _))=>
-            Some((k, RefType(ty))),
+        T(RawPtr(ty, _)) => Some((k, PtrType(ty))),
+        T(Ref(_, ty, _)) => Some((k, RefType(ty))),
         // for tuples the element types are provided
-        T(Tuple(tys))  =>
-            Some((k, TupleType(tys))),
+        T(Tuple(tys)) => Some((k, TupleType(tys))),
         // function types (fun ptrs, closures, FnDef) are provided as strings to avoid dangling ty references
-        T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => 
-            Some((k, FunType(format!("{}", k)))),
+        T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => Some((k, FunType(format!("{}", k)))),
         // other types are not provided either
-        T(Foreign(_)) | T(Pat(_, _)) | T(Coroutine(_, _, _)) | T(Dynamic(_, _, _)) | T(CoroutineWitness(_, _)) => None,
+        T(Foreign(_))
+        | T(Pat(_, _))
+        | T(Coroutine(_, _, _))
+        | T(Dynamic(_, _, _))
+        | T(CoroutineWitness(_, _)) => None,
         TyKind::Alias(_, _) | TyKind::Param(_) | TyKind::Bound(_, _) => None,
         _ => None, // redundant because of first 4 cases, but rustc does not understand that
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -969,6 +969,7 @@ pub enum TypeMetadata {
     RefType(stable_mir::ty::Ty),
     TupleType(Vec<stable_mir::ty::Ty>),
     FunType(String),
+    ClosureType(String),
 }
 
 fn mk_type_metadata(
@@ -1020,7 +1021,9 @@ fn mk_type_metadata(
         // for tuples the element types are provided
         T(Tuple(tys)) => Some((k, TupleType(tys))),
         // function types (fun ptrs, closures, FnDef) are provided as strings to avoid dangling ty references
-        T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => Some((k, FunType(format!("{}", k)))),
+        T(FnDef(_, _)) | T(FnPtr(_)) => Some((k, FunType(format!("{}", k)))),
+        // avoid printing user-dependent locations
+        T(Closure(_, _)) => Some((k, ClosureType(format!("{}", k)))),
         // other types are not provided either
         T(Foreign(_))
         | T(Pat(_, _))

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -969,7 +969,6 @@ pub enum TypeMetadata {
     RefType(stable_mir::ty::Ty),
     TupleType(Vec<stable_mir::ty::Ty>),
     FunType(String),
-    ClosureType(String),
 }
 
 fn mk_type_metadata(
@@ -1020,10 +1019,8 @@ fn mk_type_metadata(
         T(Ref(_, ty, _)) => Some((k, RefType(ty))),
         // for tuples the element types are provided
         T(Tuple(tys)) => Some((k, TupleType(tys))),
-        // function types (fun ptrs, closures, FnDef) are provided as strings to avoid dangling ty references
-        T(FnDef(_, _)) | T(FnPtr(_)) => Some((k, FunType(format!("{}", k)))),
-        // avoid printing user-dependent locations
-        T(Closure(_, _)) => Some((k, ClosureType(format!("{}", k)))),
+        // opaque function types (fun ptrs, closures, FnDef) are only provided to avoid dangling ty references
+        T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => Some((k, FunType(format!("{}", k)))),
         // other types are not provided either
         T(Foreign(_))
         | T(Pat(_, _))

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -979,7 +979,7 @@ pub enum TypeMetadata {
     PtrType(stable_mir::ty::Ty),
     RefType(stable_mir::ty::Ty),
     TupleType {
-        types: Vec<stable_mir::ty::Ty>
+        types: Vec<stable_mir::ty::Ty>,
     },
     FunType(String),
 }
@@ -1031,7 +1031,7 @@ fn mk_type_metadata(
         T(RawPtr(ty, _)) => Some((k, PtrType(ty))),
         T(Ref(_, ty, _)) => Some((k, RefType(ty))),
         // for tuples the element types are provided
-        T(Tuple(tys)) => Some((k, TupleType{types: tys})),
+        T(Tuple(tys)) => Some((k, TupleType { types: tys })),
         // opaque function types (fun ptrs, closures, FnDef) are only provided to avoid dangling ty references
         T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => Some((k, FunType(format!("{}", k)))),
         // other types are not provided either

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -978,7 +978,9 @@ pub enum TypeMetadata {
     ArrayType(stable_mir::ty::Ty, Option<stable_mir::ty::TyConst>),
     PtrType(stable_mir::ty::Ty),
     RefType(stable_mir::ty::Ty),
-    TupleType(Vec<stable_mir::ty::Ty>),
+    TupleType {
+        types: Vec<stable_mir::ty::Ty>
+    },
     FunType(String),
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1031,7 +1031,7 @@ fn mk_type_metadata(
         T(RawPtr(ty, _)) => Some((k, PtrType(ty))),
         T(Ref(_, ty, _)) => Some((k, RefType(ty))),
         // for tuples the element types are provided
-        T(Tuple(tys)) => Some((k, TupleType(tys))),
+        T(Tuple(tys)) => Some((k, TupleType{types: tys})),
         // opaque function types (fun ptrs, closures, FnDef) are only provided to avoid dangling ty references
         T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => Some((k, FunType(format!("{}", k)))),
         // other types are not provided either

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -960,6 +960,15 @@ pub enum TypeMetadata {
         name: String,
         adt_def: AdtDef,
     },
+    UnionType {
+        name: String,
+        adt_def: AdtDef,
+    },
+    ArrayType(stable_mir::ty::Ty, Option<stable_mir::ty::TyConst>),
+    PtrType(stable_mir::ty::Ty),
+    RefType(stable_mir::ty::Ty),
+    TupleType(Vec<stable_mir::ty::Ty>),
+    FunType(String),
 }
 
 fn mk_type_metadata(
@@ -968,11 +977,13 @@ fn mk_type_metadata(
     t: TyKind,
 ) -> Option<(stable_mir::ty::Ty, TypeMetadata)> {
     use TypeMetadata::*;
+    use stable_mir::ty::RigidTy::*;
+    use TyKind::RigidTy as T;
     match t {
-        TyKind::RigidTy(prim_type) if t.is_primitive() => Some((k, PrimitiveType(prim_type))),
+        T(prim_type) if t.is_primitive() => Some((k, PrimitiveType(prim_type))),
         // for enums, we need a mapping of variantIdx to discriminant
         // this requires access to the internals and is not provided as an interface function at the moment
-        TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_enum() => {
+        T(Adt(adt_def, _)) if t.is_enum() => {
             let adt_internal = rustc_internal::internal(tcx, adt_def);
             let discriminants = adt_internal
                 .discriminants(tcx)
@@ -989,11 +1000,38 @@ fn mk_type_metadata(
             ))
         }
         // for structs, we record the name for information purposes
-        TyKind::RigidTy(RigidTy::Adt(adt_def, _)) if t.is_struct() => {
+        T(Adt(adt_def, _)) if t.is_struct() => {
             let name = adt_def.name();
             Some((k, StructType { name, adt_def }))
         }
-        _ => None,
+        // for unions, we only record the name
+        T(Adt(adt_def, _)) if t.is_union() => {
+            let name = adt_def.name();
+            Some((k, UnionType { name, adt_def }))
+        }
+        // encode str together with primitive types
+        T(Str) =>
+            Some((k, PrimitiveType(Str))),
+        // for arrays and slices, record element type and optional size
+        T(Array(ty, ty_const)) =>
+            Some((k, ArrayType(ty, Some(ty_const)))),
+        T(Slice(ty)) =>
+            Some((k, ArrayType(ty, None))),
+        // for raw pointers and references store the pointee type
+        T(RawPtr(ty, _)) =>
+            Some((k, PtrType(ty))),
+        T(Ref(_, ty, _))=>
+            Some((k, RefType(ty))),
+        // for tuples the element types are provided
+        T(Tuple(tys))  =>
+            Some((k, TupleType(tys))),
+        // function types (fun ptrs, closures, FnDef) are provided as strings to avoid dangling ty references
+        T(FnDef(_, _)) | T(FnPtr(_)) | T(Closure(_, _)) => 
+            Some((k, FunType(format!("{}", k)))),
+        // other types are not provided either
+        T(Foreign(_)) | T(Pat(_, _)) | T(Coroutine(_, _, _)) | T(Dynamic(_, _, _)) | T(CoroutineWitness(_, _)) => None,
+        TyKind::Alias(_, _) | TyKind::Param(_) | TyKind::Bound(_, _) => None,
+        _ => None, // redundant because of first 4 cases, but rustc does not understand that
     }
 }
 

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -10,7 +10,7 @@
 { allocs:    .allocs,
   functions: .functions,
   items:     .items,
-  types: [
+  types: ( [
 # sort by constructors and remove unstable IDs within each
     ( .types | map(select(.[0].PrimitiveType)) ),
   # delete unstable adt_ref IDs
@@ -27,5 +27,5 @@
     ( .types | map(select(.[0].FunType)) ),
   # replace closure type strings
     ( .types | map(select(.[0].ClosureType) | .[0].ClosureType = "elided") )
-  ]
+  ] | flatten(1) )
 }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -1,27 +1,29 @@
 # Remove the hashes at the end of mangled names
 .functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = .[1].NormalSym[:-17] else .  end ] )
     | .items = ( [ .items[] | if .symbol_name then .symbol_name = .symbol_name[:-17] else .  end ] )
+# delete unstable alloc, function, and type IDs
+    | .allocs    = ( [ .allocs[]    ] | map(del(.[0])) )
+    | .functions = ( [ .functions[] ] | map(del(.[0])) )
+    | .types     =  ( [ .types[] ] | map(del(.[0])) )
     |
 # Apply the normalisation filter
-{ allocs:
-    ( [ .allocs[] ]
-# delete unstable alloc ID
-        | map(del(.[0]))
-    ),
-  functions:
-    ( [ .functions[] ]
-# delete unstable function ID
-        | map(del(.[0]))
-    ),
-  items:
-    ( [ .items[] ]
-    ),
-  types:
-    ( [ .types[] ]
-# delete unstable Ty ID (int, first in list)
-        | map(del(.[0]))
-# delete unstable adt_def from Struct and Enum
-        | map(del(.[0].StructType.adt_def))
-        | map(del(.[0].EnumType.adt_def))
-    )
+{ allocs:    .allocs,
+  functions: .functions,
+  items:     .items,
+  types: [
+# sort by constructors and remove unstable IDs within each
+    ( .types | map(select(.[0].PrimitiveType)) ),
+  # delete unstable adt_ref IDs
+    ( .types | map(select(.[0].EnumType) | del(.[0].EnumType.adt_def)) ),
+    ( .types | map(select(.[0].StructType) | del(.[0].StructType.adt_def)) ),
+    ( .types | map(select(.[0].UnionType) | del(.[0].UnionType.adt_def)) ),
+  # delete unstable Ty IDs for arrays and tuples
+    ( .types | map(select(.[0].ArrayType) | del(.[0].ArrayType.[0])) ),
+    ( .types | map(select(.[0].TupleType) | .[0].TupleType = "elided") ),
+  # replace unstable Ty IDs for references by zero
+    ( .types | map(select(.[0].PtrType) | .[0].PtrType = "elided") ),
+    ( .types | map(select(.[0].RefType) | .[0].RefType = "elided") ),
+  # keep function type strings
+    ( .types | map(select(.[0].FunType)))
+  ]
 }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -18,7 +18,7 @@
     ( .types | map(select(.[0].StructType) | del(.[0].StructType.adt_def)) ),
     ( .types | map(select(.[0].UnionType) | del(.[0].UnionType.adt_def)) ),
   # delete unstable Ty IDs for arrays and tuples
-    ( .types | map(select(.[0].ArrayType) | del(.[0].ArrayType.[0])) ),
+    ( .types | map(select(.[0].ArrayType) | del(.[0].ArrayType[0])) ),
     ( .types | map(select(.[0].TupleType) | .[0].TupleType = "elided") ),
   # replace unstable Ty IDs for references by zero
     ( .types | map(select(.[0].PtrType) | .[0].PtrType = "elided") ),

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -24,6 +24,8 @@
     ( .types | map(select(.[0].PtrType) | .[0].PtrType = "elided") ),
     ( .types | map(select(.[0].RefType) | .[0].RefType = "elided") ),
   # keep function type strings
-    ( .types | map(select(.[0].FunType)))
+    ( .types | map(select(.[0].FunType)) ),
+  # replace closure type strings
+    ( .types | map(select(.[0].ClosureType) | .[0].ClosureType = "elided") )
   ]
 }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -24,8 +24,6 @@
     ( .types | map(select(.[0].PtrType) | .[0].PtrType = "elided") ),
     ( .types | map(select(.[0].RefType) | .[0].RefType = "elided") ),
   # keep function type strings
-    ( .types | map(select(.[0].FunType)) ),
-  # replace closure type strings
-    ( .types | map(select(.[0].ClosureType) | .[0].ClosureType = "elided") )
+    ( .types | map(select(.[0].FunType) | .[0].FunType = "elided") )
   ] | flatten(1) )
 }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -19,7 +19,7 @@
     ( .types | map(select(.[0].UnionType) | del(.[0].UnionType.adt_def)) ),
   # delete unstable Ty IDs for arrays and tuples
     ( .types | map(select(.[0].ArrayType) | del(.[0].ArrayType[0])) ),
-    ( .types | map(select(.[0].TupleType) | .[0].TupleType = "elided") ),
+    ( .types | map(select(.[0].TupleType) | .[0].TupleType.types = "elided") ),
   # replace unstable Ty IDs for references by zero
     ( .types | map(select(.[0].PtrType) | .[0].PtrType = "elided") ),
     ( .types | map(select(.[0].RefType) | .[0].RefType = "elided") ),

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3373,11 +3373,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -3434,6 +3429,13 @@
       [
         {
           "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3120,324 +3120,306 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ],
-              [
-                2,
-                2
-              ]
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "core::panicking::AssertKind"
-          }
-        }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+            [
+              1,
+              1
             ],
-            "name": "std::option::Option"
-          }
+            [
+              2,
+              2
+            ]
+          ],
+          "name": "core::panicking::AssertKind"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::fmt::Arguments"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::fmt::Error"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::fmt::Formatter"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      {
+        "StructType": {
+          "name": "std::fmt::Arguments"
         }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Debug>::fmt}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::LowerHex>::fmt}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::UpperHex>::fmt}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Display>::fmt}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a (dyn std::fmt::Debug + 'a), &'b (dyn std::fmt::Debug + 'b), std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed_inner}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
+      {
+        "StructType": {
+          "name": "std::fmt::Error"
         }
-      ]
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::fmt::Formatter"
+        }
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Debug>::fmt}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::LowerHex>::fmt}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::UpperHex>::fmt}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Display>::fmt}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a (dyn std::fmt::Debug + 'a), &'b (dyn std::fmt::Debug + 'b), std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed_inner}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3120,151 +3120,322 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
-        }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ],
+              [
+                2,
+                2
+              ]
             ],
-            [
-              1,
-              1
+            "name": "core::panicking::AssertKind"
+          }
+        }
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              2,
-              2
-            ]
-          ],
-          "name": "core::panicking::AssertKind"
+            "name": "std::option::Option"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
-            ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::option::Option"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::fmt::Arguments"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::fmt::Error"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::fmt::Formatter"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::fmt::Arguments"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::fmt::Error"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::fmt::Formatter"
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Debug>::fmt}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::LowerHex>::fmt}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::UpperHex>::fmt}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Display>::fmt}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a (dyn std::fmt::Debug + 'a), &'b (dyn std::fmt::Debug + 'b), std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed_inner}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3268,22 +3268,30 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3343,82 +3343,82 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Debug>::fmt}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::LowerHex>::fmt}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::UpperHex>::fmt}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(&'a i32, &'b mut std::fmt::Formatter<'c>) -> std::result::Result<(), std::fmt::Error> {<i32 as std::fmt::Display>::fmt}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a (dyn std::fmt::Debug + 'a), &'b (dyn std::fmt::Debug + 'b), std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed_inner}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b, 'c> fn(core::panicking::AssertKind, &'a i32, &'b i32, std::option::Option<std::fmt::Arguments<'c>>) -> ! {core::panicking::assert_failed::<i32, i32>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9857,62 +9857,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(i32, i32) {test_binop}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9713,82 +9713,223 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Str"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::panic::Location"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::panic::Location"
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(i32, i32) {test_binop}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9887,11 +9887,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -9928,6 +9923,13 @@
       [
         {
           "FunType": "fn(i32, i32) {test_binop}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9797,17 +9797,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9713,225 +9713,207 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Str"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Str"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::panic::Location"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
+      {
+        "StructType": {
+          "name": "std::panic::Location"
         }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(i32, i32) {test_binop}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(i32, i32) {test_binop}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1749,57 +1749,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1704,12 +1704,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1639,186 +1639,168 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Char"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Char"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1639,68 +1639,184 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Char"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Char"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1779,11 +1779,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1815,6 +1810,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1930,216 +1930,198 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}, (i32, i32)) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::FnOnce<(i32, i32)>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::Fn<(i32, i32)>>::call}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ],
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}, (i32, i32)) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::FnOnce<(i32, i32)>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::Fn<(i32, i32)>>::call}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -2055,72 +2055,72 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}, (i32, i32)) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::FnOnce<(i32, i32)>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::Fn<(i32, i32)>>::call}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1930,68 +1930,214 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}, (i32, i32)) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::FnOnce<(i32, i32)>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28} as std::ops::Fn<(i32, i32)>>::call}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -2085,11 +2085,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2130,12 +2125,19 @@
       ],
       [
         {
-          "FunType": "{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-args.rs:2:15: 2:28}"
+          "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ],
       [
         {
-          "FunType": "extern \"rust-call\" fn((i32, i32)) -> i32"
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1995,22 +1995,30 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1750,70 +1750,206 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}, ()) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::FnOnce<()>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::Fn<()>>::call}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> u32"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1867,72 +1867,72 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}, ()) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::FnOnce<()>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::Fn<()>>::call}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> u32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1897,11 +1897,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1942,12 +1937,19 @@
       ],
       [
         {
-          "FunType": "{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}"
+          "FunType": "extern \"rust-call\" fn(()) -> u32"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ],
       [
         {
-          "FunType": "extern \"rust-call\" fn(()) -> u32"
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1750,208 +1750,190 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}, ()) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::FnOnce<()>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::Fn<()>>::call}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> u32"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ],
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a {closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24}, ()) -> <{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::FnOnce<()>>::Output {<{closure@/home/jost/work/RV/code/kmir/stable-mir-json/tests/integration/programs/closure-no-args.rs:2:15: 2:24} as std::ops::Fn<()>>::call}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> u32"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1817,12 +1817,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1965,12 +1965,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1893,198 +1893,180 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "Usize"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "Usize"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(usize, usize) -> bool {test}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(usize, usize) -> bool {test}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1893,75 +1893,196 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "Usize"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "Usize"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(usize, usize) -> bool {test}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -2010,62 +2010,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(usize, usize) -> bool {test}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -2040,11 +2040,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2081,6 +2076,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2071,12 +2071,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2146,11 +2146,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2182,6 +2177,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2006,68 +2006,184 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2116,57 +2116,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2006,186 +2006,168 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1757,63 +1757,189 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1902,11 +1902,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1938,6 +1933,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1872,57 +1872,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1757,191 +1757,173 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1817,12 +1817,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1538,12 +1538,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1578,52 +1578,52 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1608,11 +1608,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1639,6 +1634,13 @@
       [
         {
           "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1461,80 +1461,186 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
-        }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "Letter"
+            "name": "Letter"
+          }
         }
-      }
+      ]
+    ],
+    [
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1461,188 +1461,170 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "Letter"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "Letter"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2311,203 +2311,185 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(u32) -> u32 {fibonacci}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(u32) -> u32 {fibonacci}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2383,17 +2383,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2433,62 +2433,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(u32) -> u32 {fibonacci}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2463,11 +2463,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2504,6 +2499,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2311,75 +2311,201 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(u32) -> u32 {fibonacci}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2209,82 +2209,208 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Float": "F32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Float": "F64"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Str"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Float": "F32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Float": "F64"
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": "Bool"
-      }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2209,210 +2209,192 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Float": "F32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Float": "F64"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Str"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Float": "F32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Float": "F64"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Str"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2373,11 +2373,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2409,6 +2404,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2293,12 +2293,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2343,57 +2343,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2144,11 +2144,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2180,6 +2175,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2004,68 +2004,184 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2069,12 +2069,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2004,186 +2004,168 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2114,57 +2114,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2262,208 +2262,190 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(u32) -> bool {is_odd}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(u32) -> bool {is_even}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(u32) -> bool {is_odd}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(u32) -> bool {is_even}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2262,75 +2262,206 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(u32) -> bool {is_odd}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(u32) -> bool {is_even}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2334,17 +2334,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2384,67 +2384,67 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(u32) -> bool {is_odd}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(u32) -> bool {is_even}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2414,11 +2414,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2460,6 +2455,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1949,11 +1949,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1990,6 +1985,13 @@
       [
         {
           "FunType": "fn(std::option::Option<u32>) -> u32 {std::option::Option::<u32>::unwrap}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1795,205 +1795,187 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::option::Option"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn() -> ! {std::option::unwrap_failed}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(std::option::Option<u32>) -> u32 {std::option::Option::<u32>::unwrap}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn() -> ! {std::option::unwrap_failed}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(std::option::Option<u32>) -> u32 {std::option::Option::<u32>::unwrap}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1795,87 +1795,203 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
-        }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::option::Option"
+            "name": "std::option::Option"
+          }
         }
-      }
+      ]
+    ],
+    [
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn() -> ! {std::option::unwrap_failed}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(std::option::Option<u32>) -> u32 {std::option::Option::<u32>::unwrap}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1879,12 +1879,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1919,62 +1919,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn() -> ! {std::option::unwrap_failed}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(std::option::Option<u32>) -> u32 {std::option::Option::<u32>::unwrap}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -2021,11 +2021,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2057,6 +2052,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1869,198 +1869,180 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1941,17 +1941,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1869,75 +1869,196 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1991,57 +1991,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2071,203 +2071,185 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2143,17 +2143,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2071,75 +2071,201 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2223,11 +2223,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2264,6 +2259,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2193,62 +2193,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2143,17 +2143,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2071,203 +2071,185 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2223,11 +2223,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2264,6 +2259,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2193,62 +2193,62 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2071,75 +2071,201 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": "Bool"
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(u32) -> u32 {sum_to_n_rec}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1703,186 +1703,168 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1813,57 +1813,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1843,11 +1843,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1879,6 +1874,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1703,63 +1703,184 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1763,12 +1763,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3483,236 +3483,218 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I16"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I64"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I128"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Str"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I16"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I64"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I128"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Str"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::panic::Location"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
+      {
+        "StructType": {
+          "name": "std::panic::Location"
         }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3673,11 +3673,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -3709,6 +3704,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3483,103 +3483,234 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I16"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I64"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I128"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Str"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::panic::Location"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I16"
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I64"
+      ],
+      [
+        {
+          "FunType": "fn()"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I128"
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::panic::Location"
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3643,57 +3643,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3588,12 +3588,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4485,140 +4485,406 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Uint": "Usize"
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "Usize"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::ops::Range"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::option::Option"
+            "name": "std::option::Option"
+          }
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
-        }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
-        }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "std::array::TryFromSliceError"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::option::Option"
+            "name": "std::option::Option"
+          }
         }
-      }
+      ],
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
+            ],
+            "name": "std::result::Result"
+          }
+        }
+      ]
     ],
     [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
-            ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+      [
+        {
+          "StructType": {
+            "name": "std::ops::Range"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::array::TryFromSliceError"
+          }
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        {
+          "ArrayType": [
+            null
+          ]
+        }
+      ],
+      [
+        {
+          "ArrayType": [
+            {
+              "id": 1,
+              "kind": {
+                "Value": [
+                  0,
+                  {
+                    "align": 8,
+                    "bytes": [
+                      4,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0
+                    ],
+                    "mutability": "Mut",
+                    "provenance": {
+                      "ptrs": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "ArrayType": [
+            {
+              "id": 0,
+              "kind": {
+                "Value": [
+                  0,
+                  {
+                    "align": 8,
+                    "bytes": [
+                      2,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0
+                    ],
+                    "mutability": "Mut",
+                    "provenance": {
+                      "ptrs": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_end_index_len_fail}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_index_order_fail}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> fn(&'a [i32], std::ops::Range<usize>) -> &'a <[i32] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32] as std::ops::Index<std::ops::Range<usize>>>::index}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> fn(&'a [i32; 2], &'b [i32; 2]) -> bool {<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> fn(&'a [i32], &'b [i32; 2]) -> bool {<[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> fn(std::ops::Range<usize>, &'a [i32]) -> &'a <std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::Output {<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> unsafe fn(&'a [i32; 2], &'b [i32; 2]) -> bool {std::intrinsics::raw_eq::<[i32; 2]>}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> fn(&'a [i32; 4], std::ops::Range<usize>) -> &'a <[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::index}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> fn(&'a &[i32], &'b [i32; 2]) -> bool {<&[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4812,11 +4812,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -4883,6 +4878,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4691,12 +4691,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4485,408 +4485,389 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "Usize"
-          }
+      {
+        "PrimitiveType": {
+          "Uint": "Usize"
         }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
-            ],
-            "name": "std::option::Option"
-          }
-        }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
-            ],
-            "name": "std::result::Result"
-          }
-        }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
-            ],
-            "name": "std::option::Option"
-          }
-        }
-      ],
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
-            ],
-            "name": "std::result::Result"
-          }
-        }
-      ]
+      {
+        "PrimitiveType": "Bool"
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::ops::Range"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::array::TryFromSliceError"
-          }
-        }
-      ]
+      }
     ],
-    [],
     [
-      [
-        {
-          "ArrayType": [
-            null
-          ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
         }
-      ],
-      [
-        {
-          "ArrayType": [
-            {
-              "id": 1,
-              "kind": {
-                "Value": [
-                  0,
-                  {
-                    "align": 8,
-                    "bytes": [
-                      4,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0
-                    ],
-                    "mutability": "Mut",
-                    "provenance": {
-                      "ptrs": []
-                    }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::option::Option"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::ops::Range"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
+        }
+      }
+    ],
+    [
+      {
+        "StructType": {
+          "name": "std::array::TryFromSliceError"
+        }
+      }
+    ],
+    [
+      {
+        "ArrayType": [
+          null
+        ]
+      }
+    ],
+    [
+      {
+        "ArrayType": [
+          {
+            "id": 1,
+            "kind": {
+              "Value": [
+                0,
+                {
+                  "align": 8,
+                  "bytes": [
+                    4,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ],
+                  "mutability": "Mut",
+                  "provenance": {
+                    "ptrs": []
                   }
-                ]
-              }
+                }
+              ]
             }
-          ]
-        }
-      ],
-      [
-        {
-          "ArrayType": [
-            {
-              "id": 0,
-              "kind": {
-                "Value": [
-                  0,
-                  {
-                    "align": 8,
-                    "bytes": [
-                      2,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0
-                    ],
-                    "mutability": "Mut",
-                    "provenance": {
-                      "ptrs": []
-                    }
+          }
+        ]
+      }
+    ],
+    [
+      {
+        "ArrayType": [
+          {
+            "id": 0,
+            "kind": {
+              "Value": [
+                0,
+                {
+                  "align": 8,
+                  "bytes": [
+                    2,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ],
+                  "mutability": "Mut",
+                  "provenance": {
+                    "ptrs": []
                   }
-                ]
-              }
+                }
+              ]
             }
-          ]
-        }
-      ]
+          }
+        ]
+      }
     ],
     [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
-        }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_end_index_len_fail}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_index_order_fail}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> fn(&'a [i32], std::ops::Range<usize>) -> &'a <[i32] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32] as std::ops::Index<std::ops::Range<usize>>>::index}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> fn(&'a [i32; 2], &'b [i32; 2]) -> bool {<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> fn(&'a [i32], &'b [i32; 2]) -> bool {<[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> fn(std::ops::Range<usize>, &'a [i32]) -> &'a <std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::Output {<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> unsafe fn(&'a [i32; 2], &'b [i32; 2]) -> bool {std::intrinsics::raw_eq::<[i32; 2]>}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> fn(&'a [i32; 4], std::ops::Range<usize>) -> &'a <[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::index}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> fn(&'a &[i32], &'b [i32; 2]) -> bool {<&[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_end_index_len_fail}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_index_order_fail}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a [i32], std::ops::Range<usize>) -> &'a <[i32] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32] as std::ops::Index<std::ops::Range<usize>>>::index}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> fn(&'a [i32; 2], &'b [i32; 2]) -> bool {<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> fn(&'a [i32], &'b [i32; 2]) -> bool {<[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(std::ops::Range<usize>, &'a [i32]) -> &'a <std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::Output {<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> unsafe fn(&'a [i32; 2], &'b [i32; 2]) -> bool {std::intrinsics::raw_eq::<[i32; 2]>}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a [i32; 4], std::ops::Range<usize>) -> &'a <[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::index}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> fn(&'a &[i32], &'b [i32; 2]) -> bool {<&[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4771,102 +4771,102 @@
     ],
     [
       {
-        "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_end_index_len_fail}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(usize, usize) -> ! {core::slice::index::slice_index_order_fail}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a [i32], std::ops::Range<usize>) -> &'a <[i32] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32] as std::ops::Index<std::ops::Range<usize>>>::index}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> fn(&'a [i32; 2], &'b [i32; 2]) -> bool {<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> fn(&'a [i32], &'b [i32; 2]) -> bool {<[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> fn(std::ops::Range<usize>, &'a [i32]) -> &'a <std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::Output {<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> unsafe fn(&'a [i32; 2], &'b [i32; 2]) -> bool {std::intrinsics::raw_eq::<[i32; 2]>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a [i32; 4], std::ops::Range<usize>) -> &'a <[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::Output {<[i32; 4] as std::ops::Index<std::ops::Range<usize>>>::index}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> fn(&'a &[i32], &'b [i32; 2]) -> bool {<&[i32] as std::cmp::PartialEq<[i32; 2]>>::eq}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1760,63 +1760,189 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1820,12 +1820,16 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1875,57 +1875,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1760,191 +1760,173 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1905,11 +1905,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1941,6 +1936,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -2034,57 +2034,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1905,82 +1905,203 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U32"
+          }
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "St"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U32"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "StructType": {
-          "name": "St"
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
         }
-      }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1905,205 +1905,187 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U32"
-          }
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U32"
+        }
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "St"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
+      {
+        "StructType": {
+          "name": "St"
         }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1984,17 +1984,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -2064,11 +2064,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2100,6 +2095,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2620,67 +2620,67 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(usize) -> usize {sum_to_n}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn() {test_sum_to_n}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2498,208 +2498,190 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "Usize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "Usize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(usize) -> usize {sum_to_n}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn() {test_sum_to_n}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(usize) -> usize {sum_to_n}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn() {test_sum_to_n}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2570,17 +2570,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2650,11 +2650,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2696,6 +2691,13 @@
       [
         {
           "FunType": "fn() {test_sum_to_n}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2498,75 +2498,206 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "Usize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Uint": "Usize"
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
         }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": "Bool"
-      }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(usize) -> usize {sum_to_n}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn() {test_sum_to_n}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2455,68 +2455,209 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as std::cmp::PartialEq>::eq}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a, 'b> fn(&'a (i32, i32), &'b (i32, i32)) -> bool {<(i32, i32) as std::cmp::PartialEq>::eq}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2520,17 +2520,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2580,67 +2580,67 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as std::cmp::PartialEq>::eq}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a, 'b> fn(&'a (i32, i32), &'b (i32, i32)) -> bool {<(i32, i32) as std::cmp::PartialEq>::eq}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2455,211 +2455,193 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as std::cmp::PartialEq>::eq}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a, 'b> fn(&'a (i32, i32), &'b (i32, i32)) -> bool {<(i32, i32) as std::cmp::PartialEq>::eq}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> fn(&'a i32, &'b i32) -> bool {<i32 as std::cmp::PartialEq>::eq}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a, 'b> fn(&'a (i32, i32), &'b (i32, i32)) -> bool {<(i32, i32) as std::cmp::PartialEq>::eq}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2610,11 +2610,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -2656,6 +2651,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1751,68 +1751,189 @@
   ],
   "types": [
     [
-      {
-        "PrimitiveType": {
-          "Int": "I8"
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I8"
+          }
         }
-      }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "Isize"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Uint": "U8"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": {
+            "Int": "I32"
+          }
+        }
+      ],
+      [
+        {
+          "PrimitiveType": "Bool"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "Isize"
-        }
-      }
-    ],
-    [
-      {
-        "PrimitiveType": {
-          "Uint": "U8"
-        }
-      }
-    ],
-    [
-      {
-        "EnumType": {
-          "discriminants": [
-            [
-              0,
-              0
+      [
+        {
+          "EnumType": {
+            "discriminants": [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ]
             ],
-            [
-              1,
-              1
-            ]
-          ],
-          "name": "std::result::Result"
+            "name": "std::result::Result"
+          }
         }
-      }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::sys::pal::unix::process::process_common::ExitCode"
+      [
+        {
+          "StructType": {
+            "name": "std::sys::pal::unix::process::process_common::ExitCode"
+          }
         }
-      }
+      ],
+      [
+        {
+          "StructType": {
+            "name": "std::process::ExitCode"
+          }
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ],
+      [
+        {
+          "TupleType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": {
-          "Int": "I32"
+      [
+        {
+          "PtrType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "PtrType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "StructType": {
-          "name": "std::process::ExitCode"
+      [
+        {
+          "RefType": "elided"
         }
-      }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ],
+      [
+        {
+          "RefType": "elided"
+        }
+      ]
     ],
     [
-      {
-        "PrimitiveType": "Bool"
-      }
+      [
+        {
+          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(()) -> i32"
+        }
+      ],
+      [
+        {
+          "FunType": "fn()"
+        }
+      ],
+      [
+        {
+          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        }
+      ],
+      [
+        {
+          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        }
+      ],
+      [
+        {
+          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        }
+      ],
+      [
+        {
+          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
     ]
   ]
 }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1751,191 +1751,173 @@
   ],
   "types": [
     [
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I8"
-          }
+      {
+        "PrimitiveType": {
+          "Int": "I8"
         }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "Isize"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Uint": "U8"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": {
-            "Int": "I32"
-          }
-        }
-      ],
-      [
-        {
-          "PrimitiveType": "Bool"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "EnumType": {
-            "discriminants": [
-              [
-                0,
-                0
-              ],
-              [
-                1,
-                1
-              ]
+      {
+        "PrimitiveType": {
+          "Int": "Isize"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Uint": "U8"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": {
+          "Int": "I32"
+        }
+      }
+    ],
+    [
+      {
+        "PrimitiveType": "Bool"
+      }
+    ],
+    [
+      {
+        "EnumType": {
+          "discriminants": [
+            [
+              0,
+              0
             ],
-            "name": "std::result::Result"
-          }
+            [
+              1,
+              1
+            ]
+          ],
+          "name": "std::result::Result"
         }
-      ]
+      }
     ],
     [
-      [
-        {
-          "StructType": {
-            "name": "std::sys::pal::unix::process::process_common::ExitCode"
-          }
+      {
+        "StructType": {
+          "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
-      ],
-      [
-        {
-          "StructType": {
-            "name": "std::process::ExitCode"
-          }
-        }
-      ]
-    ],
-    [],
-    [],
-    [
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ],
-      [
-        {
-          "TupleType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "PtrType": "elided"
+      {
+        "StructType": {
+          "name": "std::process::ExitCode"
         }
-      ],
-      [
-        {
-          "PtrType": "elided"
-        }
-      ]
+      }
     ],
     [
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ],
-      [
-        {
-          "RefType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(()) -> i32"
-        }
-      ],
-      [
-        {
-          "FunType": "fn()"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
-        }
-      ],
-      [
-        {
-          "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
-        }
-      ],
-      [
-        {
-          "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
-        }
-      ],
-      [
-        {
-          "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
     ],
     [
-      [
-        {
-          "ClosureType": "elided"
-        }
-      ]
+      {
+        "TupleType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "PtrType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "RefType": "elided"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(()) -> i32"
+      }
+    ],
+    [
+      {
+        "FunType": "fn()"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+      }
+    ],
+    [
+      {
+        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+      }
+    ],
+    [
+      {
+        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+      }
+    ],
+    [
+      {
+        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+      }
+    ],
+    [
+      {
+        "ClosureType": "elided"
+      }
     ]
   ]
 }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1816,17 +1816,23 @@
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [
       {
-        "TupleType": "elided"
+        "TupleType": {
+          "types": "elided"
+        }
       }
     ],
     [

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1866,57 +1866,57 @@
     ],
     [
       {
-        "FunType": "for<'a> fn(&'a (dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe + 'a), isize, *const *const u8, u8) -> std::result::Result<isize, !> {std::rt::lang_start_internal}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(()) -> i32"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn()"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) -> std::process::ExitCode {<() as std::process::Termination>::report}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn(fn(), ()) -> <fn() as std::ops::FnOnce<()>>::Output {<fn() as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(()) {std::intrinsics::black_box::<()>}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "extern \"rust-call\" fn({closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "for<'a> extern \"rust-call\" fn(&'a mut {closure@std::rt::lang_start<()>::{closure#0}}, ()) -> <{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::Output {<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnMut<()>>::call_mut}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        "FunType": "elided"
       }
     ],
     [
       {
-        "ClosureType": "elided"
+        "FunType": "elided"
       }
     ]
   ]

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1896,11 +1896,6 @@
       ],
       [
         {
-          "FunType": "{closure@std::rt::lang_start<()>::{closure#0}}"
-        }
-      ],
-      [
-        {
           "FunType": "fn(fn()) {std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>}"
         }
       ],
@@ -1932,6 +1927,13 @@
       [
         {
           "FunType": "fn(&'static str) -> ! {core::panicking::panic}"
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "ClosureType": "elided"
         }
       ]
     ]

--- a/tests/ui/run_ui_tests.sh
+++ b/tests/ui/run_ui_tests.sh
@@ -13,6 +13,8 @@ RUST_DIR_ROOT="$1"
 UI_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PASSING_TSV="${UI_DIR}/passing.tsv"
 
+KEEP_FILES=${KEEP_FILES:-""}
+
 echo "Running regression tests for passing UI cases..."
 failed=0
 
@@ -30,7 +32,7 @@ while read -r test; do
     fi
 
     # Clean up generated JSON
-    [ -f "$json_file" ] && rm -f "$json_file"
+    [ -z "$KEEP_FILES" ] && [ -f "$json_file" ] && rm -f "$json_file"
 done < "$PASSING_TSV"
 
 if [ $failed -ne 0 ]; then


### PR DESCRIPTION
Emit metadata for all types that matter, in particular reference types and array types.
Function types are only referred to as strings (elided in the golden tests), some other types are still not considered but they don't seem relevant to our purpose.

Also included:
* add type of `TyConst` in `RigidTy::Array` case to collected types in `collect_ty`
* optionally keep json files after running `test-ui`

| RigidTy                                          | Metadata      | Information     |           |
|--------------------------------------------------|---------------|-----------------|-----------|
| Bool                                             | PrimitiveType | RigidTy         | existed   |
| Char                                             | PrimitiveType | RigidTy         | existed   |
| Int(IntTy)                                       | PrimitiveType | RigidTy         | existed   |
| Uint(UintTy)                                     | PrimitiveType | RigidTy         | existed   |
| Float(FloatTy)                                   | PrimitiveType | RigidTy         | existed   |
| Adt(AdtDef, GenericArgs)                         | EnumType      |                 | existed   |
|                                                  | StructType    |                 | existed   |
|                                                  | UnionType     |                 | ADDED     |
| Foreign(ForeignDef)                              |               |                 |           |
| Str                                              | PrimitiveType | RigidTy         | ADDED     |
| Array(Ty, TyConst)                               | ArrayType     | ElemType, len   | ADDED     |
| Pat(Ty, Pattern)                                 |               |                 |           |
| Slice(Ty)                                        | ArrayType     | ElemType        | ADDED     |
| RawPtr(Ty, Mutability)                           | PtrType       | PointeeType     | ADDED     |
| Ref(Region, Ty, Mutability)                      | RefType       | PointeeType     | ADDED     |
| FnDef(FnDef, GenericArgs)                        | FunType       | type string only| ADDED     |
| FnPtr(PolyFnSig)                                 | FunType       | type string only| ADDED     |
| Closure(ClosureDef, GenericArgs)                 | FunType       | type string only| ADDED     |
| Coroutine(CoroutineDef, GenericArgs, Movability) |               |                 |           |
| Dynamic(Vec<Binder<Ex-Pred>>, Region, DynKind)   |               |                 |           |
| Never                                            |               |                 | ?         |
| Tuple(Vec<Ty>)                                   | TupleType     | Component types | ADDED     |
| CoroutineWitness(..)                             |               |                 |           |
