### PR TITLE
Fixed `VERBOSE` env var reading in `Makefile`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   update-deps:
     name: "Update Dependents"
+    runs-on: [self-hosted, linux, normal]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ remake-ui-tests:
 	# This will run without saving source files. Run the script manually to do this.
 	bash tests/ui/remake_ui_tests.sh "$$RUST_DIR_ROOT"
 
-test-ui: VERBOSE=0
+test-ui: VERBOSE?=0
 test-ui:
 	# Check if RUST_DIR_ROOT is set
 	if [ -z "$$RUST_DIR_ROOT" ]; then \


### PR DESCRIPTION
The make target `test-ui` takes a verbosity flag to print the output. This flag is provided as env var `VERBOSE`, but this was not being read properly from the environment and was always set to `0`