### PR TITLE
Use git rev-parse to get master version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 'Update dependents'
         run: |
           set -x
-          VERSION=${{ github.event.push.head.sha }}
+          VERSION=$(git rev-parse HEAD)
           curl --fail                                                          \
             -X POST                                                            \
             -H "Accept: application/vnd.github+json"                           \


### PR DESCRIPTION
Blocked on: https://github.com/runtimeverification/devops/pull/234
Blocked on: https://github.com/runtimeverification/mir-semantics/pull/561

This uses `git rev-parse` instead of relying on github action variables to get the version to push, as the prior attempt didn't end up including the label.