### PR TITLE
`MachineInfo` in JSON

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1076,6 +1076,7 @@ pub struct SmirJson<'t> {
     pub types: Vec<(stable_mir::ty::Ty, TypeMetadata)>,
     pub spans: Vec<(usize, SourceData)>,
     pub debug: Option<SmirJsonDebugInfo<'t>>,
+    pub machine: stable_mir::target::MachineInfo,
 }
 
 #[derive(Serialize)]
@@ -1160,6 +1161,7 @@ pub fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
         types,
         spans,
         debug,
+        machine: stable_mir::target::MachineInfo::target(),
     }
 }
 


### PR DESCRIPTION
Added [MachineInfo](https://github.com/rust-lang/rust/blob/a2545fd6fc66b4323f555223a860c451885d1d2b/compiler/stable_mir/src/target.rs#L7-L12) to the JSON. This should give us the ability to use `usize` properly