### PR TITLE
Add a list of field types to struct type metadata

### DIFF
--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -13,9 +13,9 @@
   types: ( [
 # sort by constructors and remove unstable IDs within each
     ( .types | map(select(.[0].PrimitiveType)) | sort ),
-  # delete unstable adt_ref IDs
+  # delete unstable adt_ref IDs and struct field Ty IDs
     ( .types | map(select(.[0].EnumType) | del(.[0].EnumType.adt_def)) | sort ),
-    ( .types | map(select(.[0].StructType) | del(.[0].StructType.adt_def)) | sort ),
+    ( .types | map(select(.[0].StructType) | del(.[0].StructType.adt_def) | .[0].StructType.fields = "elided" ) | sort ),
     ( .types | map(select(.[0].UnionType) | del(.[0].UnionType.adt_def)) | sort ),
   # delete unstable Ty IDs for arrays and tuples
     ( .types | map(select(.[0].ArrayType) | del(.[0].ArrayType[0]) | del(.[0].ArrayType[0].id)) | sort ),

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -3227,6 +3227,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::fmt::Arguments"
         }
       }
@@ -3234,6 +3235,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::fmt::Error"
         }
       }
@@ -3241,6 +3243,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::fmt::Formatter"
         }
       }
@@ -3248,6 +3251,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -3255,6 +3259,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -3262,6 +3267,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9770,6 +9770,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -9777,6 +9778,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -9784,6 +9786,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1689,6 +1689,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1696,6 +1697,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1703,6 +1705,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -1980,6 +1980,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1987,6 +1988,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1994,6 +1996,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1802,6 +1802,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1809,6 +1810,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1816,6 +1818,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -1950,6 +1950,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1957,6 +1958,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1964,6 +1966,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2056,6 +2056,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2063,6 +2064,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2070,6 +2072,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1802,6 +1802,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1809,6 +1810,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1816,6 +1818,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1518,6 +1518,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1525,6 +1526,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2368,6 +2368,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2375,6 +2376,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2382,6 +2384,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2273,6 +2273,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2280,6 +2281,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2287,6 +2289,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2054,6 +2054,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2061,6 +2062,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2068,6 +2070,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2319,6 +2319,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2326,6 +2327,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2333,6 +2335,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -1859,6 +1859,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1866,6 +1867,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1873,6 +1875,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -1926,6 +1926,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1933,6 +1934,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1940,6 +1942,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2128,6 +2128,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2135,6 +2136,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2142,6 +2144,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2128,6 +2128,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2135,6 +2136,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2142,6 +2144,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1748,6 +1748,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1755,6 +1756,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1762,6 +1764,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3568,6 +3568,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -3575,6 +3576,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -3582,6 +3584,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -4593,6 +4593,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::array::TryFromSliceError"
         }
       }
@@ -4600,6 +4601,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::ops::Range"
         }
       }
@@ -4607,6 +4609,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -4614,6 +4617,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -4621,6 +4625,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1805,6 +1805,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1812,6 +1813,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1819,6 +1821,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -1962,6 +1962,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "St"
         }
       }
@@ -1969,6 +1970,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1976,6 +1978,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1983,6 +1986,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2555,6 +2555,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2562,6 +2563,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2569,6 +2571,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2505,6 +2505,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -2512,6 +2513,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -2519,6 +2521,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -1801,6 +1801,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::panic::Location"
         }
       }
@@ -1808,6 +1809,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::process::ExitCode"
         }
       }
@@ -1815,6 +1817,7 @@
     [
       {
         "StructType": {
+          "fields": "elided",
           "name": "std::sys::pal::unix::process::process_common::ExitCode"
         }
       }


### PR DESCRIPTION
This adds the field types of the single variant of a `struct` `RigidTy::Adt` to the type metadata, similar to the `types` field of `TupleType`

Closes #81 