### PR TITLE
HOTFIX normalise field types before emitting them

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -564,7 +564,7 @@ impl Visitor for TyCollector<'_> {
                     .all_fields()
                     .map(|field| {
                         self.tcx.instantiate_and_normalize_erasing_regions(
-                            &args,
+                            args,
                             TypingEnv::fully_monomorphized(),
                             self.tcx.type_of(field.did),
                         )
@@ -1069,10 +1069,11 @@ fn mk_type_metadata(
                         .iter()
                         .map(|field| {
                             tcx.instantiate_and_normalize_erasing_regions(
-                                &args,
+                                args,
                                 TypingEnv::fully_monomorphized(),
                                 tcx.type_of(field.did),
-                            )})
+                            )
+                        })
                         .map(rustc_internal::stable)
                         .collect::<Vec<stable_mir::ty::Ty>>()
                 })
@@ -1094,10 +1095,11 @@ fn mk_type_metadata(
                 .all_fields() // is_struct, so only one variant
                 .map(|field| {
                     tcx.instantiate_and_normalize_erasing_regions(
-                        &args,
+                        args,
                         TypingEnv::fully_monomorphized(),
                         tcx.type_of(field.did),
-                    )})
+                    )
+                })
                 .map(rustc_internal::stable)
                 .collect();
             Some((
@@ -1122,7 +1124,10 @@ fn mk_type_metadata(
         T(Str) => Some((k, PrimitiveType(Str))),
         // for arrays and slices, record element type and optional size
         T(Array(elem_type, ty_const)) => {
-            if matches!(ty_const.kind(), stable_mir::ty::TyConstKind::Unevaluated(_, _)) {
+            if matches!(
+                ty_const.kind(),
+                stable_mir::ty::TyConstKind::Unevaluated(_, _)
+            ) {
                 panic!("Unevaluated constant {ty_const:?} in type {k}");
             }
             Some((

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -5674,65 +5674,6 @@
                   "Initialized": {
                     "valid_range": {
                       "end": 18446744073709551615,
-                      "start": 0
-                    },
-                    "value": {
-                      "Int": {
-                        "length": "I64",
-                        "signed": false
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            "abi_align": 8,
-            "fields": {
-              "Arbitrary": {
-                "offsets": [
-                  {
-                    "num_bits": 0
-                  },
-                  {
-                    "num_bits": 64
-                  }
-                ]
-              }
-            },
-            "size": {
-              "num_bits": 128
-            },
-            "variants": {
-              "Single": {
-                "index": 0
-              }
-            }
-          },
-          "pointee_type": "elided"
-        }
-      }
-    ],
-    [
-      {
-        "RefType": {
-          "layout": {
-            "abi": {
-              "ScalarPair": [
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
-                      "start": 1
-                    },
-                    "value": {
-                      "Pointer": 0
-                    }
-                  }
-                },
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
                       "start": 1
                     },
                     "value": {


### PR DESCRIPTION
The `Ty`s found in field information can contain `AliasTy` as well as `ParamTy`, and potentially have unevaluated constants.
Also now panicking if an unevaluated constant is found in array type metadata.

In the discussion, it was pointed out that the variant fields can be obtained using `stable_mir` crate (interface) methods only, so I refactored the code to not use internals where possible.

Related Zulip discussion:[#project-stable-mir > Visiting ADT field types, problem with unevaluated constants](https://rust-lang.zulipchat.com/#narrow/channel/320896-project-stable-mir/topic/Visiting.20ADT.20field.20types.2C.20problem.20with.20unevaluated.20constants)