### PR TITLE
fix: add rust-analyzer to flake.nix and rust-toolchain.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             zlib
             jq
             gnumake
+            rust-analyzer
           ];
 
           env = {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-11-29"
-components = ["llvm-tools", "rustc-dev", "rust-src"]
+components = ["llvm-tools", "rustc-dev", "rust-src", "rust-analyzer"]


### PR DESCRIPTION
This PR adds `rust-analyzer` to the Nix dev shell and the pinned Rust toolchain to improve editor tooling when working with this repository.

See issue for details: https://github.com/runtimeverification/stable-mir-json/issues/113

Closes #113.