### PR TITLE
Removing rust-analyzer from nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,6 @@
             zlib
             jq
             gnumake
-            rust-analyzer
           ];
 
           env = {


### PR DESCRIPTION
Removed rust-analyzer from nix as it is in rust-toolchain.toml