### PR TITLE
d2: remove unreachable early return in legend rendering

### DIFF
--- a/src/mk_graph/output/d2.rs
+++ b/src/mk_graph/output/d2.rs
@@ -44,9 +44,6 @@ impl SmirJson<'_> {
 
 fn render_d2_allocs_legend(ctx: &GraphContext, out: &mut String) {
     let legend_lines = ctx.allocs_legend_lines();
-    if legend_lines.is_empty() {
-        return;
-    }
 
     out.push_str("ALLOCS: {\n");
     out.push_str("  style.fill: \"#ffffcc\"\n");


### PR DESCRIPTION
## Summary

Follow up from a review comment on PR #111.

Removes an unreachable early return in D2 legend rendering.

## Problem

In `src/mk_graph/output/d2.rs`:
```
let legend_lines = ctx.allocs_legend_lines();
if legend_lines.is_empty() {
    return;
}
```

As pointed out by @dkcumming, `allocs_legend_lines()` always inserts the `"ALLOCS"` header, so this condition can never be true.

## Change

Remove the dead branch and rely on the invariant guaranteed by `allocs_legend_lines()`.

## Diff

```diff
 fn render_d2_allocs_legend(ctx: &GraphContext, out: &mut String) {
     let legend_lines = ctx.allocs_legend_lines();
-    if legend_lines.is_empty() {
-        return;
-    }

     out.push_str("ALLOCS: {\n");
     out.push_str("  style.fill: \"#ffffcc\"\n");
```

## Review context

https://github.com/runtimeverification/stable-mir-json/pull/111#discussion_r2679439555
