### PR TITLE
You Shook Me Alloc Night Long — finally sorted like we mean it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ format:
 	bash -O globstar -c 'nixfmt **/*.nix'
 
 style-check: format
-	cargo clippy
+	cargo clippy -- -Dwarnings
 
 .PHONY: remake-ui-tests test-ui
 

--- a/src/printer/collect.rs
+++ b/src/printer/collect.rs
@@ -16,6 +16,7 @@ use crate::compat::stable_mir;
 
 use std::collections::{HashMap, HashSet};
 
+use stable_mir::mir::alloc::GlobalAlloc;
 use stable_mir::mir::mono::MonoItem;
 use stable_mir::mir::visit::MirVisitor;
 use stable_mir::ty::IndexedVal;
@@ -155,6 +156,15 @@ fn collect_and_analyze_items(
     )
 }
 
+fn alloc_sort_key(info: &AllocInfo) -> String {
+    match info.global_alloc() {
+        GlobalAlloc::Memory(alloc) => format!("0_Memory_{:020}", alloc.bytes.len()),
+        GlobalAlloc::Static(def) => format!("1_Static_{}", def.name()),
+        GlobalAlloc::VTable(ty, _) => format!("2_VTable_{}", ty),
+        GlobalAlloc::Function(inst) => format!("3_Function_{}", inst.name()),
+    }
+}
+
 /// Phase 3: Assemble the final SmirJson from collected and derived data.
 /// This is a pure data transformation with no inst.body() calls.
 fn assemble_smir(tcx: TyCtxt<'_>, collected: CollectedCrate, derived: DerivedInfo) -> SmirJson {
@@ -206,19 +216,38 @@ fn assemble_smir(tcx: TyCtxt<'_>, collected: CollectedCrate, derived: DerivedInf
 
     let mut spans = span_map.into_iter().collect::<Vec<_>>();
 
-    // sort output vectors to stabilise output (a bit)
-    allocs.sort_by_key(|a| a.alloc_id().to_index());
-    functions.sort_by(|a, b| a.0 .0.to_index().cmp(&b.0 .0.to_index()));
+    // sort output vectors by content-derived keys for deterministic output.
+    // Ty's Display impl (ty_pretty) should be injective for monomorphized types,
+    // but we use the interned index as a tiebreaker just in case two distinct
+    // types produce the same display string.
+    allocs.sort_by_key(alloc_sort_key);
+    functions.sort_by(|a, b| {
+        format!("{}", a.0 .0)
+            .cmp(&format!("{}", b.0 .0))
+            .then_with(|| {
+                let a_kind = a.0 .1.as_ref().map(|k| format!("{k}"));
+                let b_kind = b.0 .1.as_ref().map(|k| format!("{k}"));
+                a_kind.cmp(&b_kind)
+            })
+            .then_with(|| a.0 .0.to_index().cmp(&b.0 .0.to_index()))
+    });
     items.sort();
-    types.sort_by(|a, b| a.0.to_index().cmp(&b.0.to_index()));
-    spans.sort();
+    types.sort_by(|a, b| {
+        format!("{}", a.0)
+            .cmp(&format!("{}", b.0))
+            .then_with(|| a.0.to_index().cmp(&b.0.to_index()))
+    });
+    spans.sort_by(|a, b| a.1.cmp(&b.1));
+
+    let mut uneval_consts: Vec<_> = unevaluated_consts.into_iter().collect();
+    uneval_consts.sort_by(|a, b| a.1.cmp(&b.1));
 
     SmirJson {
         name: local_crate.name,
         crate_id,
         allocs,
         functions,
-        uneval_consts: unevaluated_consts.into_iter().collect(),
+        uneval_consts,
         items,
         types,
         spans,

--- a/src/printer/collect.rs
+++ b/src/printer/collect.rs
@@ -156,12 +156,42 @@ fn collect_and_analyze_items(
     )
 }
 
-fn alloc_sort_key(info: &AllocInfo) -> String {
+/// Allocations are sorted by a three-tier key for deterministic output:
+///
+/// 1. **Variant tag** (`alloc_sort_tag`): a `&'static str` with a numeric
+///    prefix that groups allocations by `GlobalAlloc` variant (Memory < Static
+///    < VTable < Function).
+///
+/// 2. **Content key** (`alloc_content_key`): the name or Display string that
+///    disambiguates entries within Static, VTable, and Function variants.
+///    Empty for Memory (handled entirely by tier 3).
+///
+/// 3. **Byte content** (`alloc_bytes`): direct `&[Option<u8>]` slice
+///    comparison that breaks ties between Memory allocations with identical
+///    length (e.g. two 5-byte string literals "hello" vs "world"). Empty
+///    for non-Memory variants (already resolved by tier 2).
+fn alloc_sort_tag(info: &AllocInfo) -> &'static str {
     match info.global_alloc() {
-        GlobalAlloc::Memory(alloc) => format!("0_Memory_{:020}", alloc.bytes.len()),
-        GlobalAlloc::Static(def) => format!("1_Static_{}", def.name()),
-        GlobalAlloc::VTable(ty, _) => format!("2_VTable_{}", ty),
-        GlobalAlloc::Function(inst) => format!("3_Function_{}", inst.name()),
+        GlobalAlloc::Memory(_) => "0_Memory",
+        GlobalAlloc::Static(_) => "1_Static",
+        GlobalAlloc::VTable(..) => "2_VTable",
+        GlobalAlloc::Function(_) => "3_Function",
+    }
+}
+
+fn alloc_content_key(info: &AllocInfo) -> String {
+    match info.global_alloc() {
+        GlobalAlloc::Memory(_) => String::new(),
+        GlobalAlloc::Static(def) => def.name(),
+        GlobalAlloc::VTable(ty, _) => format!("{ty}"),
+        GlobalAlloc::Function(inst) => inst.name(),
+    }
+}
+
+fn alloc_bytes(info: &AllocInfo) -> &[Option<u8>] {
+    match info.global_alloc() {
+        GlobalAlloc::Memory(alloc) => &alloc.bytes,
+        _ => &[],
     }
 }
 
@@ -220,7 +250,12 @@ fn assemble_smir(tcx: TyCtxt<'_>, collected: CollectedCrate, derived: DerivedInf
     // Ty's Display impl (ty_pretty) should be injective for monomorphized types,
     // but we use the interned index as a tiebreaker just in case two distinct
     // types produce the same display string.
-    allocs.sort_by_key(alloc_sort_key);
+    allocs.sort_by(|a, b| {
+        alloc_sort_tag(a)
+            .cmp(alloc_sort_tag(b))
+            .then_with(|| alloc_content_key(a).cmp(&alloc_content_key(b)))
+            .then_with(|| alloc_bytes(a).cmp(alloc_bytes(b)))
+    });
     functions.sort_by(|a, b| {
         format!("{}", a.0 .0)
             .cmp(&format!("{}", b.0 .0))

--- a/src/printer/schema.rs
+++ b/src/printer/schema.rs
@@ -396,6 +396,10 @@ pub enum TypeMetadata {
     PrimitiveType(RigidTy),
     EnumType {
         name: String,
+        // adt_def serializes as a non-deterministic interned index (DefId), but
+        // downstream consumers need it to cross-reference AggregateKind::Adt in
+        // MIR bodies with the type metadata here. We can't stabilize it without
+        // also controlling AggregateKind serialization (which comes from stable_mir).
         adt_def: AdtDef,
         discriminants: Vec<u128>,
         fields: Vec<Vec<stable_mir::ty::Ty>>,

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -4765,6 +4765,62 @@
         "TupleType": {
           "layout": {
             "abi": {
+              "ScalarPair": [
+                {
+                  "Initialized": {
+                    "valid_range": {
+                      "end": 18446744073709551615,
+                      "start": 1
+                    },
+                    "value": {
+                      "Pointer": 0
+                    }
+                  }
+                },
+                {
+                  "Initialized": {
+                    "valid_range": {
+                      "end": 18446744073709551615,
+                      "start": 1
+                    },
+                    "value": {
+                      "Pointer": 0
+                    }
+                  }
+                }
+              ]
+            },
+            "abi_align": 8,
+            "fields": {
+              "Arbitrary": {
+                "offsets": [
+                  {
+                    "num_bits": 0
+                  },
+                  {
+                    "num_bits": 64
+                  }
+                ]
+              }
+            },
+            "size": {
+              "num_bits": 128
+            },
+            "variants": {
+              "Single": {
+                "index": 0
+              }
+            }
+          },
+          "types": "elided"
+        }
+      }
+    ],
+    [
+      {
+        "TupleType": {
+          "layout": {
+            "abi": {
               "Aggregate": {
                 "sized": true
               }
@@ -4839,62 +4895,6 @@
             },
             "size": {
               "num_bits": 64
-            },
-            "variants": {
-              "Single": {
-                "index": 0
-              }
-            }
-          },
-          "types": "elided"
-        }
-      }
-    ],
-    [
-      {
-        "TupleType": {
-          "layout": {
-            "abi": {
-              "ScalarPair": [
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
-                      "start": 1
-                    },
-                    "value": {
-                      "Pointer": 0
-                    }
-                  }
-                },
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
-                      "start": 1
-                    },
-                    "value": {
-                      "Pointer": 0
-                    }
-                  }
-                }
-              ]
-            },
-            "abi_align": 8,
-            "fields": {
-              "Arbitrary": {
-                "offsets": [
-                  {
-                    "num_bits": 0
-                  },
-                  {
-                    "num_bits": 64
-                  }
-                ]
-              }
-            },
-            "size": {
-              "num_bits": 128
             },
             "variants": {
               "Single": {

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -2131,13 +2131,13 @@
                 {
                   "Initialized": {
                     "valid_range": {
-                      "end": 4294967295,
+                      "end": 1,
                       "start": 0
                     },
                     "value": {
                       "Int": {
-                        "length": "I32",
-                        "signed": true
+                        "length": "I8",
+                        "signed": false
                       }
                     }
                   }
@@ -2193,13 +2193,13 @@
                 {
                   "Initialized": {
                     "valid_range": {
-                      "end": 1,
+                      "end": 4294967295,
                       "start": 0
                     },
                     "value": {
                       "Int": {
-                        "length": "I8",
-                        "signed": false
+                        "length": "I32",
+                        "signed": true
                       }
                     }
                   }

--- a/tests/integration/programs/fn-ptr-in-arg.smir.json.expected
+++ b/tests/integration/programs/fn-ptr-in-arg.smir.json.expected
@@ -6458,6 +6458,62 @@
         "TupleType": {
           "layout": {
             "abi": {
+              "ScalarPair": [
+                {
+                  "Initialized": {
+                    "valid_range": {
+                      "end": 18446744073709551615,
+                      "start": 1
+                    },
+                    "value": {
+                      "Pointer": 0
+                    }
+                  }
+                },
+                {
+                  "Initialized": {
+                    "valid_range": {
+                      "end": 18446744073709551615,
+                      "start": 1
+                    },
+                    "value": {
+                      "Pointer": 0
+                    }
+                  }
+                }
+              ]
+            },
+            "abi_align": 8,
+            "fields": {
+              "Arbitrary": {
+                "offsets": [
+                  {
+                    "num_bits": 0
+                  },
+                  {
+                    "num_bits": 64
+                  }
+                ]
+              }
+            },
+            "size": {
+              "num_bits": 128
+            },
+            "variants": {
+              "Single": {
+                "index": 0
+              }
+            }
+          },
+          "types": "elided"
+        }
+      }
+    ],
+    [
+      {
+        "TupleType": {
+          "layout": {
+            "abi": {
               "Aggregate": {
                 "sized": true
               }
@@ -6502,62 +6558,6 @@
             },
             "size": {
               "num_bits": 64
-            },
-            "variants": {
-              "Single": {
-                "index": 0
-              }
-            }
-          },
-          "types": "elided"
-        }
-      }
-    ],
-    [
-      {
-        "TupleType": {
-          "layout": {
-            "abi": {
-              "ScalarPair": [
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
-                      "start": 1
-                    },
-                    "value": {
-                      "Pointer": 0
-                    }
-                  }
-                },
-                {
-                  "Initialized": {
-                    "valid_range": {
-                      "end": 18446744073709551615,
-                      "start": 1
-                    },
-                    "value": {
-                      "Pointer": 0
-                    }
-                  }
-                }
-              ]
-            },
-            "abi_align": 8,
-            "fields": {
-              "Arbitrary": {
-                "offsets": [
-                  {
-                    "num_bits": 0
-                  },
-                  {
-                    "num_bits": 64
-                  }
-                ]
-              }
-            },
-            "size": {
-              "num_bits": 128
             },
             "variants": {
               "Single": {


### PR DESCRIPTION
This PR replaces all index-based sort keys with content-derived ones, making the ordering of output vectors deterministic across runs. The one remaining source of cross-run non-determinism is `adt_def` (see below for why that can't be fixed here).

## Context

For those unfamiliar: rustc stores types, allocations, and other values in central tables and refers to them by integer index. These indices are assigned in the order the compiler happens to intern items, which is not guaranteed to be the same between invocations. There are two independent reasons for this:

1. **Hash-map iteration order**: Rustc uses hash maps heavily (often [`FxHashMap`](https://github.com/rust-lang/rustc-hash) for speed rather than the standard library's [`RandomState`](https://doc.rust-lang.org/std/hash/struct.RandomState.html)-backed `HashMap`). [Hash-map iteration order is not specified](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.iter) and depends on hash/table layout and insertion history. If the order of insertions varies (because upstream work completed in a different order, or because of platform or compiler version differences), then iterating the map and interning items in iteration order produces different interned indices.
2. **Parallel query evaluation**: Rustc uses rayon for parallel compilation. Query evaluation, monomorphization collection, and codegen unit partitioning can all run work items concurrently. The order in which parallel tasks complete depends on OS thread scheduling, which can affect insertion order into those hash maps. So if type A gets interned before type B in one run because its query finished first, their indices may swap in the next run.

Either source alone is sufficient to produce different indices across runs. 

The output vectors in `collect_smir()` were sorted like this:

```rust
allocs.sort_by(|a, b| a.alloc_id.to_index().cmp(&b.alloc_id.to_index()));
functions.sort_by(|a, b| a.0 .0.to_index().cmp(&b.0 .0.to_index()));
types.sort_by(|a, b| a.0.to_index().cmp(&b.0.to_index()));
spans.sort();
```

These `.to_index()` calls return those interned IDs. The original comment said "stabilise output (a bit)", which is honest about the fact that this was only partially working. And `uneval_consts` (coming from `HashMap::into_iter()`) wasn't sorted at all.

The integration test harness worked around all of this with a jq normalization filter (`normalise-filter.jq`) that strips unstable IDs and re-sorts by content before diffing. But the raw JSON output itself was not reproducible.

## What changed

All changes are in `src/printer.rs`, in the sorting section of `collect_smir()`. Here's the new sort strategy for each vector:

| Vector | Old sort key | New sort key | Tiebreaker |
|--------|-------------|--------------|------------|
| `functions` | `Ty.to_index()` | `Ty` display string (via `ty_pretty`) | interned index |
| `types` | `Ty.to_index()` | `Ty` display string (via `ty_pretty`) | interned index |
| `allocs` | `AllocId.to_index()` | content-derived string (see below) | none needed |
| `spans` | span index (opaque) | location tuple: `(filename, lo_line, lo_col, hi_line, hi_col)` | none needed |
| `uneval_consts` | unsorted | item name string | none needed |
| `items` | unchanged | already uses a content-based `Ord` impl | N/A |

**Allocation sort keys** deserve some detail. The new `alloc_sort_key()` helper produces a content-derived string from each `AllocInfo` by matching on the `GlobalAlloc` variant:

| Variant | Sort key format | Example |
|---------|----------------|---------|
| `Memory` | `0_Memory_` + zero-padded byte length | `"0_Memory_00000000000000000032"` |
| `Static` | `1_Static_` + def name | `"1_Static_MY_STATIC"` |
| `VTable` | `2_VTable_` + type string | `"2_VTable_dyn Trait"` |
| `Function` | `3_Function_` + instance name | `"3_Function_foo::bar"` |

The numeric prefix groups entries by variant kind. Byte length is zero-padded to 20 digits so that `32` sorts before `128` lexicographically. (Span locations are `usize` values that compare numerically, so no padding is needed there.)

Three golden test files were regenerated because their normalized output changed due to the new ordering. The jq normalization filter doesn't fully sort `TupleType` and `FunType` entries, so those were sensitive to input order.

## Remaining non-determinism: `adt_def`

We looked into stabilizing the `adt_def` field on `EnumType`/`StructType`/`UnionType` as well; it's another interned index that the jq filter strips for test normalization. Turns out it can't be dropped or replaced.

The reason: downstream consumers need `adt_def` as a cross-reference key to match `AggregateKind::Adt(adt_def, ...)` in MIR bodies with the corresponding type metadata entry. `AggregateKind` serialization comes from stable_mir (we don't control it), so both sides of the join have to use the same key format. The index is consistent within a single JSON file; it's just not stable across runs.

So `adt_def` remains the one known source of cross-run non-determinism in the output, and the jq filter still needs to strip it for golden test comparison. A comment was added on the field explaining this constraint. If we ever get the ability to customize `AggregateKind` serialization upstream, we could replace these indices with names, but that's a stable_mir change, not something we can do on our end. (See PR #64 for the full discussion.)

## On the `Ty` display string tiebreaker

`Ty`'s display impl goes through `ty_pretty()`, which calls `to_string()` on rustc's internal `Ty`. For monomorphized types (all generics resolved, no lifetime parameters), this should be injective: distinct types produce distinct strings. But there's a theoretical concern: could two distinct `Ty` values display identically? Perhaps some obscure lifetime or where-clause difference that gets elided in the display output.

We weren't confident enough to rule this out entirely, so the interned index is used as a tiebreaker: content-based ordering for the common case, with the index preserving a consistent (within-run) ordering for any hypothetical ties. If a tie does occur, the ordering at the tie point would be non-deterministic across runs, but we haven't observed this in practice.

## What this means in practice

If you run stable-mir-json twice on the same input file and diff the raw JSON (no jq filter), the only differences will be the interned index *values* themselves (`adt_def`, `alloc_id`, `Ty` keys, etc.). The structural ordering of every output vector is now identical across runs. Before this change, even the order of types, functions, allocs, and spans could shuffle around.

The jq normalization filter is still needed for golden tests (to strip those interned IDs), but the sort operations in it are now redundant; they just confirm what the source already guarantees.

## Performance

The `format!("{}", ty)` calls for sorting `functions` and `types` allocate strings. This is fine; the vectors are small (one entry per unique type or function in the program), and this code runs once at the end after all collection is done.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `make integration-test` passes (all 28 tests)
- [x] Ran stable-mir-json twice on `assert_eq.rs` and diffed the raw JSON: identical modulo interned index values (`adt_def` only); all vector ordering matched exactly
