### PR TITLE
Added mutability to `PtrType` and `RefType` `TypeInfo`

### DIFF
--- a/src/mk_graph/index.rs
+++ b/src/mk_graph/index.rs
@@ -51,13 +51,30 @@ pub struct TypeEntry {
 #[derive(Clone)]
 pub enum TypeKind {
     Primitive,
-    Struct { fields: Vec<FieldInfo> },
-    Enum { variants: Vec<VariantInfo> },
-    Union { fields: Vec<FieldInfo> },
-    Array { elem_ty: Ty, len: Option<u64> },
-    Tuple { fields: Vec<Ty> },
-    Ptr { pointee: Ty },
-    Ref { pointee: Ty },
+    Struct {
+        fields: Vec<FieldInfo>,
+    },
+    Enum {
+        variants: Vec<VariantInfo>,
+    },
+    Union {
+        fields: Vec<FieldInfo>,
+    },
+    Array {
+        elem_ty: Ty,
+        len: Option<u64>,
+    },
+    Tuple {
+        fields: Vec<Ty>,
+    },
+    Ptr {
+        pointee: Ty,
+        mutability: stable_mir::mir::Mutability,
+    },
+    Ref {
+        pointee: Ty,
+        mutability: stable_mir::mir::Mutability,
+    },
     Function,
     Void,
 }
@@ -365,12 +382,14 @@ impl TypeEntry {
             TypeMetadata::PtrType {
                 pointee_type,
                 layout,
+                mutability,
             } => {
                 let layout_info = layout.as_ref().map(LayoutInfo::from_shape);
                 (
                     format!("{}", ty),
                     TypeKind::Ptr {
                         pointee: *pointee_type,
+                        mutability: *mutability,
                     },
                     layout_info,
                 )
@@ -378,12 +397,14 @@ impl TypeEntry {
             TypeMetadata::RefType {
                 pointee_type,
                 layout,
+                mutability,
             } => {
                 let layout_info = layout.as_ref().map(LayoutInfo::from_shape);
                 (
                     format!("{}", ty),
                     TypeKind::Ref {
                         pointee: *pointee_type,
+                        mutability: *mutability,
                     },
                     layout_info,
                 )

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1338,10 +1338,12 @@ pub enum TypeMetadata {
     PtrType {
         pointee_type: stable_mir::ty::Ty,
         layout: Option<LayoutShape>,
+        mutability: stable_mir::mir::Mutability,
     },
     RefType {
         pointee_type: stable_mir::ty::Ty,
         layout: Option<LayoutShape>,
+        mutability: stable_mir::mir::Mutability,
     },
     TupleType {
         types: Vec<stable_mir::ty::Ty>,
@@ -1459,18 +1461,20 @@ fn mk_type_metadata(
             },
         )),
         // for raw pointers and references store the pointee type
-        T(RawPtr(pointee_type, _)) => Some((
+        T(RawPtr(pointee_type, mutability)) => Some((
             k,
             PtrType {
                 pointee_type,
                 layout,
+                mutability,
             },
         )),
-        T(Ref(_, pointee_type, _)) => Some((
+        T(Ref(_, pointee_type, mutability)) => Some((
             k,
             RefType {
                 pointee_type,
                 layout,
+                mutability,
             },
         )),
         // for tuples the element types are provided

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -4934,6 +4934,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4966,6 +4967,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4998,6 +5000,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5030,6 +5033,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5062,6 +5066,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5094,6 +5099,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5126,6 +5132,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5158,6 +5165,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5190,6 +5198,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5222,6 +5231,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5254,6 +5264,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5286,6 +5297,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5318,6 +5330,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5377,6 +5390,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5436,6 +5450,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5495,6 +5510,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5554,6 +5570,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5610,6 +5627,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5666,6 +5684,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5722,6 +5741,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -9794,6 +9794,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -9826,6 +9827,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -9858,6 +9860,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -9890,6 +9893,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -9922,6 +9926,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -9954,6 +9959,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -9986,6 +9992,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -10045,6 +10052,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -10101,6 +10109,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -1855,6 +1855,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1887,6 +1888,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1919,6 +1921,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1951,6 +1954,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1983,6 +1987,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2015,6 +2020,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2047,6 +2053,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2106,6 +2113,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2162,6 +2170,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -2260,6 +2260,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2292,6 +2293,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2324,6 +2326,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2356,6 +2359,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2388,6 +2392,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2420,6 +2425,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2452,6 +2458,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2484,6 +2491,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2543,6 +2551,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2599,6 +2608,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -1955,6 +1955,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1987,6 +1988,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2019,6 +2021,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2051,6 +2054,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2083,6 +2087,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2115,6 +2120,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2147,6 +2153,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2179,6 +2186,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2238,6 +2246,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2294,6 +2303,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -2108,6 +2108,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2140,6 +2141,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2172,6 +2174,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2204,6 +2207,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2236,6 +2240,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2268,6 +2273,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2300,6 +2306,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2359,6 +2366,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2415,6 +2423,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -2209,6 +2209,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2241,6 +2242,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2273,6 +2275,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2305,6 +2308,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2337,6 +2341,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2369,6 +2374,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2401,6 +2407,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2460,6 +2467,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2516,6 +2524,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -1965,6 +1965,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1997,6 +1998,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2029,6 +2031,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2061,6 +2064,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2093,6 +2097,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2125,6 +2130,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2157,6 +2163,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2189,6 +2196,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2221,6 +2229,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2280,6 +2289,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2336,6 +2346,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -1733,6 +1733,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1765,6 +1766,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1797,6 +1799,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1829,6 +1832,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1861,6 +1865,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1893,6 +1898,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1949,6 +1955,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -2572,6 +2572,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2604,6 +2605,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2636,6 +2638,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2668,6 +2671,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2700,6 +2704,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2732,6 +2737,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2764,6 +2770,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2823,6 +2830,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2879,6 +2887,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -2421,6 +2421,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2453,6 +2454,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2485,6 +2487,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2517,6 +2520,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2549,6 +2553,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2581,6 +2586,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2613,6 +2619,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2672,6 +2679,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2728,6 +2736,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/fn-ptr-in-arg.smir.json.expected
+++ b/tests/integration/programs/fn-ptr-in-arg.smir.json.expected
@@ -6597,6 +6597,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -6629,6 +6630,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -6661,6 +6663,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -6693,6 +6696,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6725,6 +6729,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6757,6 +6762,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6789,6 +6795,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -6821,6 +6828,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -6853,6 +6861,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6885,6 +6894,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6917,6 +6927,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6949,6 +6960,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -6981,6 +6993,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7013,6 +7026,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7045,6 +7059,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7077,6 +7092,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7136,6 +7152,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7195,6 +7212,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7254,6 +7272,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7313,6 +7332,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7369,6 +7389,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -7425,6 +7446,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -7481,6 +7503,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -2207,6 +2207,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2239,6 +2240,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2271,6 +2273,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2303,6 +2306,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2335,6 +2339,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2367,6 +2372,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2399,6 +2405,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2458,6 +2465,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2514,6 +2522,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -2524,6 +2524,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2556,6 +2557,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2588,6 +2590,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2620,6 +2623,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2652,6 +2656,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2684,6 +2689,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2716,6 +2722,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2775,6 +2782,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2831,6 +2839,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -2148,6 +2148,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2180,6 +2181,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2212,6 +2214,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2244,6 +2247,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2276,6 +2280,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2308,6 +2313,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2340,6 +2346,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2399,6 +2406,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2455,6 +2463,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/param_types.smir.json.expected
+++ b/tests/integration/programs/param_types.smir.json.expected
@@ -4753,6 +4753,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4785,6 +4786,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4817,6 +4819,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -4849,6 +4852,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -4881,6 +4885,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4913,6 +4918,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -4945,6 +4951,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -4977,6 +4984,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5009,6 +5017,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5041,6 +5050,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5100,6 +5110,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5156,6 +5167,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5212,6 +5224,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5268,6 +5281,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -2140,6 +2140,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2172,6 +2173,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2204,6 +2206,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2236,6 +2239,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2268,6 +2272,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2300,6 +2305,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2332,6 +2338,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2391,6 +2398,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2447,6 +2455,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -2339,6 +2339,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2371,6 +2372,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2403,6 +2405,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2435,6 +2438,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2467,6 +2471,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2499,6 +2504,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2531,6 +2537,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2590,6 +2597,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2646,6 +2654,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -2339,6 +2339,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2371,6 +2372,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2403,6 +2405,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2435,6 +2438,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2467,6 +2471,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2499,6 +2504,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2531,6 +2537,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2590,6 +2597,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2646,6 +2654,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -1913,6 +1913,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -1945,6 +1946,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -1977,6 +1979,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2009,6 +2012,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2041,6 +2045,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2073,6 +2078,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2105,6 +2111,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2137,6 +2144,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2196,6 +2204,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2252,6 +2261,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -3673,6 +3673,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3705,6 +3706,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3737,6 +3739,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3769,6 +3772,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3801,6 +3805,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3833,6 +3838,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3865,6 +3871,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3924,6 +3931,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3980,6 +3988,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -5265,6 +5265,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5297,6 +5298,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5329,6 +5331,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5361,6 +5364,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5393,6 +5397,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5452,6 +5457,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5484,6 +5490,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -5516,6 +5523,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5548,6 +5556,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5580,6 +5589,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5612,6 +5622,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5644,6 +5655,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5676,6 +5688,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5735,6 +5748,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5794,6 +5808,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -5850,6 +5865,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -1968,6 +1968,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2000,6 +2001,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2032,6 +2034,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2064,6 +2067,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2096,6 +2100,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2128,6 +2133,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2160,6 +2166,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2192,6 +2199,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2224,6 +2232,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2283,6 +2292,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2339,6 +2349,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -2239,6 +2239,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2271,6 +2272,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2303,6 +2305,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2335,6 +2338,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2367,6 +2371,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2399,6 +2404,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2431,6 +2437,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2490,6 +2497,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2546,6 +2554,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -2760,6 +2760,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2792,6 +2793,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2824,6 +2826,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2856,6 +2859,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2888,6 +2892,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2920,6 +2925,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2952,6 +2958,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3011,6 +3018,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3067,6 +3075,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -2712,6 +2712,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2744,6 +2745,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2776,6 +2778,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2808,6 +2811,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2840,6 +2844,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2872,6 +2877,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2904,6 +2910,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2936,6 +2943,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2968,6 +2976,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3027,6 +3036,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3083,6 +3093,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -2026,6 +2026,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2058,6 +2059,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2090,6 +2092,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2122,6 +2125,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -2154,6 +2158,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2186,6 +2191,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2218,6 +2224,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2277,6 +2284,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -2333,6 +2341,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }

--- a/tests/integration/programs/weirdRefs.smir.json.expected
+++ b/tests/integration/programs/weirdRefs.smir.json.expected
@@ -3379,6 +3379,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3411,6 +3412,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3443,6 +3445,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3475,6 +3478,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3507,6 +3511,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3539,6 +3544,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3571,6 +3577,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3603,6 +3610,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3635,6 +3643,7 @@
               }
             }
           },
+          "mutability": "Mut",
           "pointee_type": "elided"
         }
       }
@@ -3667,6 +3676,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3699,6 +3709,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3731,6 +3742,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3790,6 +3802,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }
@@ -3846,6 +3859,7 @@
               }
             }
           },
+          "mutability": "Not",
           "pointee_type": "elided"
         }
       }


### PR DESCRIPTION
An error was seen with `PtrToPtr` casts in mir-semantics when there is an array of arrays being cast to change mutability. The current model incorrectly assumes it wants to point to an interior element, but this case needs to be distinguished from the case that is purely changing mutability. Therefore the mutability of the pointer needs to be accessible in the `TypeInfo`