### PR TITLE
Human-Readable Symbol Names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ integration-test: NORMALIZE ?= jq -S -e -f $(TESTDIR)/../normalise-filter.jq
 integration-test: DIFF      ?= | diff -
 integration-test:
 	errors=""; \
-	report() { echo "$$1: $$2"; errors="$$errors\n$$1: $$2"; }; \
+	report() { printf "%s: %s\n" "$$1" "$$2"; errors="$$errors\n$$1: $$2"; }; \
 	for rust in ${TESTS}; do \
 		target=$${rust%.rs}.smir.json; \
 		dir=$$(dirname $${rust}); \
@@ -37,7 +37,7 @@ integration-test:
 			&& rm $${target} \
 			|| report "$$rust" "Unexpected json output"; \
 		done; \
-	[ -z "$$errors" ] || (echo "===============\nFAILING TESTS:$$errors"; exit 1)
+	[ -z "$$errors" ] || (printf "===============\nFAILING TESTS:%s\n" "$$errors"; exit 1)
 
 
 golden:
@@ -48,7 +48,7 @@ test-skip-lang-start: TESTS ?= $(shell find $(TESTDIR) -type f -name "*.rs")
 test-skip-lang-start: SMIR  ?= cargo run -- --d2 "-Zno-codegen"
 test-skip-lang-start:
 	errors=""; \
-	report() { echo "FAIL: $$1: $$2"; errors="$$errors\n$$1: $$2"; }; \
+	report() { printf "FAIL: %s: %s\n" "$$1" "$$2"; errors="$$errors\n$$1: $$2"; }; \
 	for rust in ${TESTS}; do \
 		dir=$$(dirname $${rust}); \
 		name=$$(basename $${rust} .rs); \
@@ -58,7 +58,7 @@ test-skip-lang-start:
 			|| { report "$$rust" "Conversion failed"; continue; }; \
 		rm -f $${d2}; \
 	done; \
-	[ -z "$$errors" ] || (echo "===============\nFAILING TESTS:$$errors"; exit 1)
+	[ -z "$$errors" ] || (printf "===============\nFAILING TESTS:%s\n" "$$errors"; exit 1)
 
 format: 
 	cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,26 @@ integration-test:
 golden:
 	make integration-test DIFF=">"
 
+.PHONY: test-skip-lang-start
+test-skip-lang-start: TESTS ?= $(shell find $(TESTDIR) -type f -name "*.rs")
+test-skip-lang-start: SMIR  ?= cargo run -- --d2 "-Zno-codegen"
+test-skip-lang-start:
+	errors=""; \
+	report() { echo "FAIL: $$1: $$2"; errors="$$errors\n$$1: $$2"; }; \
+	for rust in ${TESTS}; do \
+		dir=$$(dirname $${rust}); \
+		name=$$(basename $${rust} .rs); \
+		d2=$${dir}/$${name}.smir.d2; \
+		echo "$$rust"; \
+		SKIP_LANG_START=1 ${SMIR} --out-dir $${dir} $${rust} \
+			|| { report "$$rust" "Conversion failed"; continue; }; \
+		if grep -q 'lang_start' $${d2} 2>/dev/null; then \
+			report "$$rust" "Output still contains lang_start"; \
+		fi; \
+		rm -f $${d2}; \
+	done; \
+	[ -z "$$errors" ] || (echo "===============\nFAILING TESTS:$$errors"; exit 1)
+
 format: 
 	cargo fmt
 	bash -O globstar -c 'nixfmt **/*.nix'

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ OUTDIR_SVG=output-svg
 OUTDIR_PNG=output-png
 OUTDIR_D2=output-d2
 
+# Pass UNMANGLE=1 to demangle symbol names in graph output.
+# Pass SKIPLANGSTART=1 to filter out std::rt::lang_start items.
+GRAPH_ENV := $(if $(UNMANGLE),GRAPH_UNMANGLE=1) $(if $(SKIPLANGSTART),SKIP_LANG_START=1)
+
 clean-graphs:
 	@rm -rf $(OUTDIR_DOT) $(OUTDIR_SVG) $(OUTDIR_PNG) $(OUTDIR_D2)
 
@@ -105,7 +109,7 @@ dot:
 	@for rs in $(TESTDIR)/*.rs; do \
 		name=$$(basename $$rs .rs); \
 		echo "Generating $$name.smir.dot"; \
-		cargo run --release -- --dot -Zno-codegen $$rs 2>/dev/null; \
+		$(GRAPH_ENV) cargo run --release -- --dot -Zno-codegen $$rs 2>/dev/null; \
 		mv $$name.smir.dot $(OUTDIR_DOT)/ 2>/dev/null || true; \
 	done
 
@@ -130,6 +134,6 @@ d2:
 	@for rs in $(TESTDIR)/*.rs; do \
 		name=$$(basename $$rs .rs); \
 		echo "Generating $$name.smir.d2"; \
-		cargo run --release -- --d2 -Zno-codegen $$rs 2>/dev/null; \
+		$(GRAPH_ENV) cargo run --release -- --d2 -Zno-codegen $$rs 2>/dev/null; \
 		mv $$name.smir.d2 $(OUTDIR_D2)/ 2>/dev/null || true; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,8 @@ test-skip-lang-start:
 		name=$$(basename $${rust} .rs); \
 		d2=$${dir}/$${name}.smir.d2; \
 		echo "$$rust"; \
-		SKIP_LANG_START=1 ${SMIR} --out-dir $${dir} $${rust} \
+		SKIP_LANG_START=1 ASSERT_FILTER=1 ${SMIR} --out-dir $${dir} $${rust} \
 			|| { report "$$rust" "Conversion failed"; continue; }; \
-		if grep -q 'lang_start' $${d2} 2>/dev/null; then \
-			report "$$rust" "Output still contains lang_start"; \
-		fi; \
 		rm -f $${d2}; \
 	done; \
 	[ -z "$$errors" ] || (echo "===============\nFAILING TESTS:$$errors"; exit 1)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ make png   # Generate .png files in output-png/ (requires graphviz)
 make d2    # Generate .d2 files in output-d2/
 ```
 
+These targets accept optional flags that compose freely:
+
+```shell
+make svg UNMANGLE=1                       # Demangle symbol names in labels
+make svg SKIPLANGSTART=1                  # Filter out std::rt::lang_start items
+make svg UNMANGLE=1 SKIPLANGSTART=1       # Both
+```
+
 There are a few environment variables that can be set to control the tools output:
 
 1.  `LINK_ITEMS` - add entries to the link-time `functions` map for each monomorphic item in the crate;
@@ -71,7 +79,8 @@ These tests are stored [in `src/tests/integration/failing`](./src/tests/integrat
 To run the tests, do the following:
 
 ```shell
-make integration-test
+make integration-test          # Golden-file JSON tests
+make test-skip-lang-start      # Verify SKIP_LANG_START filtering works
 ```
 
 ## Integration with `cargo`

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -25,6 +25,7 @@
 //! `DefId`, etc.) without requiring them to know which rustc crate the
 //! type actually lives in.
 
+pub extern crate rustc_demangle;
 pub extern crate rustc_middle;
 pub extern crate rustc_monomorphize;
 pub extern crate rustc_session;

--- a/src/mk_graph/context.rs
+++ b/src/mk_graph/context.rs
@@ -11,6 +11,8 @@ use stable_mir::ty::{ConstantKind, IndexedVal, MirConst, Ty};
 
 use crate::printer::SmirJson;
 
+use crate::compat::rustc_demangle::demangle;
+
 use super::index::{AllocIndex, LayoutInfo, TypeEntry, TypeIndex, TypeKind};
 use super::util::{function_string, short_fn_name, GraphLabelString};
 
@@ -23,23 +25,48 @@ pub struct GraphContext {
     pub allocs: AllocIndex,
     pub types: TypeIndex,
     pub functions: HashMap<Ty, String>,
+    /// When `GRAPH_UNMANGLE=1`, maps mangled symbol names to demangled
+    /// display names. Empty otherwise. Renderers should call
+    /// `display_name()` for labels rather than using `functions` values
+    /// directly.
+    display_names: HashMap<String, String>,
 }
 
 impl GraphContext {
     pub fn from_smir(smir: &SmirJson) -> Self {
         let types = TypeIndex::from_types(&smir.types);
         let allocs = AllocIndex::from_alloc_infos(&smir.allocs, &types);
+        let unmangle = std::env::var("GRAPH_UNMANGLE").is_ok();
         let functions: HashMap<Ty, String> = smir
             .functions
             .iter()
             .map(|(k, v)| (k.0, function_string(v.clone())))
             .collect();
+        let display_names: HashMap<String, String> = if unmangle {
+            functions
+                .values()
+                .map(|name| (name.clone(), demangle(name).to_string()))
+                .collect()
+        } else {
+            HashMap::new()
+        };
 
         Self {
             allocs,
             types,
             functions,
+            display_names,
         }
+    }
+
+    /// Return the display-friendly name for a symbol. When
+    /// `GRAPH_UNMANGLE=1` is set this is the demangled form;
+    /// otherwise it's the original (mangled) name.
+    pub fn display_name<'a>(&'a self, name: &'a str) -> &'a str {
+        self.display_names
+            .get(name)
+            .map(|s| s.as_str())
+            .unwrap_or(name)
     }
 
     /// Render a constant operand with alloc information
@@ -78,7 +105,7 @@ impl GraphContext {
                 // Function pointers, unit type, etc.
                 if ty.kind().is_fn() {
                     if let Some(name) = self.functions.get(&ty) {
-                        format!("const fn {}", short_fn_name(name))
+                        format!("const fn {}", short_fn_name(self.display_name(name)))
                     } else {
                         format!("const {}", ty_name)
                     }
@@ -240,7 +267,7 @@ impl GraphContext {
             } => {
                 let fn_name = self
                     .resolve_call_target(func)
-                    .map(|n| short_fn_name(&n))
+                    .map(|n| short_fn_name(self.display_name(&n)))
                     .unwrap_or_else(|| "?".to_string());
                 let arg_str = args
                     .iter()

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -24,13 +24,51 @@ pub use index::{AllocEntry, AllocIndex, AllocKind, TypeIndex};
 pub use util::GraphLabelString;
 
 // =============================================================================
-// Lang Start Filtering
+// Item Filtering
 // =============================================================================
 
-pub(crate) fn skip_lang_start() -> bool {
-    use std::sync::OnceLock;
-    static VAR: OnceLock<bool> = OnceLock::new();
-    *VAR.get_or_init(|| std::env::var("SKIP_LANG_START").is_ok())
+/// A predicate that identifies items to exclude from graph output.
+/// Each variant corresponds to an environment variable that enables it.
+pub(crate) enum ItemFilter {
+    /// Exclude `std::rt::lang_start` and items only reachable through it.
+    /// Enabled by `SKIP_LANG_START=1`.
+    LangStart,
+}
+
+impl ItemFilter {
+    /// Return the set of filters currently enabled via environment variables.
+    pub fn enabled() -> Vec<ItemFilter> {
+        let mut filters = Vec::new();
+        if std::env::var("SKIP_LANG_START").is_ok() {
+            filters.push(ItemFilter::LangStart);
+        }
+        filters
+    }
+
+    /// Compute the set of symbol names this filter wants to exclude.
+    pub fn compute_exclusions(&self, items: &[Item], ctx: &GraphContext) -> HashSet<String> {
+        match self {
+            ItemFilter::LangStart => compute_lang_start_exclusions(items, ctx),
+        }
+    }
+
+    /// Apply all enabled filters: collect exclusions, then prune both
+    /// `items` and `ctx.functions` in one pass.
+    ///
+    /// After this call, `ctx.resolve_call_target()` returns `None` for any
+    /// excluded function, so renderers don't need a separate exclusion set.
+    pub fn apply_all(items: &mut Vec<Item>, ctx: &mut GraphContext) {
+        let filters = Self::enabled();
+        if filters.is_empty() {
+            return;
+        }
+        let mut excluded = HashSet::new();
+        for filter in &filters {
+            excluded.extend(filter.compute_exclusions(items, ctx));
+        }
+        items.retain(|i| !excluded.contains(&i.symbol_name));
+        ctx.functions.retain(|_, name| !excluded.contains(name));
+    }
 }
 
 /// Compute the set of symbol names to exclude from graph rendering.
@@ -43,7 +81,7 @@ pub(crate) fn skip_lang_start() -> bool {
 /// 3. Find entry-point items (not called by any other item)
 /// 4. BFS from non-seed entry points, not entering seed nodes
 /// 5. Everything not reachable gets excluded
-pub(crate) fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) -> HashSet<String> {
+fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) -> HashSet<String> {
     // Build forward call graph: symbol_name -> list of callee names
     let mut call_graph: HashMap<&str, Vec<&str>> = HashMap::new();
     for item in items {
@@ -87,7 +125,6 @@ pub(crate) fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) 
         let name = item.symbol_name.as_str();
         let is_entry = !has_callers.contains(name);
         if is_entry && !seed_names.contains(name) {
-            // some items call other items
             reachable.insert(name);
             queue.push_back(name);
         }
@@ -108,7 +145,7 @@ pub(crate) fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) 
     let all_names: HashSet<&str> = items
         .iter()
         .map(|i| i.symbol_name.as_str())
-        .chain(ctx.functions.values().map(|s| s.as_str())) // chain external functions too
+        .chain(ctx.functions.values().map(|s| s.as_str()))
         .collect();
 
     all_names

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -22,11 +22,25 @@ pub use index::{AllocEntry, AllocIndex, AllocKind, TypeIndex};
 pub use util::GraphLabelString;
 
 // =============================================================================
+// Lang Start Filtering
+// =============================================================================
+
+pub(crate) fn skip_lang_start() -> bool {
+    use std::sync::OnceLock;
+    static VAR: OnceLock<bool> = OnceLock::new();
+    *VAR.get_or_init(|| std::env::var("SKIP_LANG_START").is_ok())
+}
+
+// =============================================================================
 // Entry Points
 // =============================================================================
 
 /// Entry point to write the DOT file
 pub fn emit_dotfile(tcx: TyCtxt<'_>) {
+    if skip_lang_start() {
+        println!("SKIP_LANG_START is set");
+    }
+
     let smir_dot = collect_smir(tcx).to_dot_file();
 
     match mir_output_path(tcx, "smir.dot") {

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -29,6 +29,7 @@ pub use util::GraphLabelString;
 
 /// A predicate that identifies items to exclude from graph output.
 /// Each variant corresponds to an environment variable that enables it.
+#[derive(Debug)]
 pub(crate) enum ItemFilter {
     /// Exclude `std::rt::lang_start` and items only reachable through it.
     /// Enabled by `SKIP_LANG_START=1`.
@@ -58,17 +59,60 @@ impl ItemFilter {
     ///
     /// After this call, `ctx.resolve_call_target()` returns `None` for any
     /// excluded function, so renderers don't need a separate exclusion set.
+    ///
+    /// When `ASSERT_FILTER=1` is set (intended for integration tests), this
+    /// asserts that each filter actually matched something and that no
+    /// matching items survive after filtering.
     pub fn apply_all(items: &mut Vec<Item>, ctx: &mut GraphContext) {
         let filters = Self::enabled();
         if filters.is_empty() {
             return;
         }
+        let assert_mode = std::env::var("ASSERT_FILTER").is_ok();
         let mut excluded = HashSet::new();
         for filter in &filters {
-            excluded.extend(filter.compute_exclusions(items, ctx));
+            let filter_excluded = filter.compute_exclusions(items, ctx);
+            // The precondition assert checks that the test input actually
+            // contains items this filter targets. For LangStart, this holds
+            // for any crate with `fn main` because rustc always emits
+            // `std::rt::lang_start` as the runtime entry wrapper. If a test
+            // program is a library crate (no main), lang_start won't be
+            // present and this assert will fire; in that case, either skip
+            // the lib crate in test-skip-lang-start or gate LangStart on
+            // the presence of a main function.
+            if assert_mode {
+                assert!(
+                    !filter_excluded.is_empty(),
+                    "ASSERT_FILTER: {:?} matched no items. \
+                     If the test input is a library crate (no fn main), \
+                     std::rt::lang_start won't be present; either exclude \
+                     lib crates from test-skip-lang-start or adjust the \
+                     filter precondition.",
+                    filter
+                );
+            }
+            excluded.extend(filter_excluded);
         }
         items.retain(|i| !excluded.contains(&i.symbol_name));
         ctx.functions.retain(|_, name| !excluded.contains(name));
+        if assert_mode {
+            for filter in &filters {
+                assert!(
+                    !filter.survives(items),
+                    "ASSERT_FILTER: {:?} items survived filtering",
+                    filter
+                );
+            }
+        }
+    }
+
+    /// Check whether any items matching this filter remain after filtering.
+    fn survives(&self, items: &[Item]) -> bool {
+        match self {
+            ItemFilter::LangStart => items
+                .iter()
+                .any(|i| is_std_rt_lang_start(&i.mono_item_kind)),
+        }
     }
 }
 

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -138,20 +138,7 @@ fn is_std_rt_lang_start(kind: &MonoItemKind) -> bool {
 
 /// Entry point to write the DOT file
 pub fn emit_dotfile(tcx: TyCtxt<'_>) {
-    let smir = collect_smir(tcx);
-
-    if skip_lang_start() {
-        let ctx = GraphContext::from_smir(&smir);
-        let excluded = compute_lang_start_exclusions(&smir.items, &ctx);
-        println!("SKIP_LANG_START: excluding {} items:", excluded.len());
-        let mut sorted: Vec<_> = excluded.iter().collect();
-        sorted.sort();
-        for name in sorted {
-            println!("  - {}", name);
-        }
-    }
-
-    let smir_dot = smir.to_dot_file();
+    let smir_dot = collect_smir(tcx).to_dot_file();
 
     match mir_output_path(tcx, "smir.dot") {
         OutputDest::Stdout => {

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -38,11 +38,12 @@ pub(crate) enum ItemFilter {
 impl ItemFilter {
     /// Return the set of filters currently enabled via environment variables.
     pub fn enabled() -> Vec<ItemFilter> {
-        let mut filters = Vec::new();
-        if std::env::var("SKIP_LANG_START").is_ok() {
-            filters.push(ItemFilter::LangStart);
-        }
-        filters
+        [std::env::var("SKIP_LANG_START")
+            .ok()
+            .map(|_| Self::LangStart)]
+        .into_iter()
+        .flatten()
+        .collect()
     }
 
     /// Compute the set of symbol names this filter wants to exclude.
@@ -92,15 +93,12 @@ fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) -> HashSet<
             let callees: Vec<&str> = body
                 .blocks
                 .iter()
-                .filter_map(|block| {
-                    if let TerminatorKind::Call {
+                .filter_map(|block| match &block.terminator.kind {
+                    TerminatorKind::Call {
                         func: Operand::Constant(ConstOperand { const_, .. }),
                         ..
-                    } = &block.terminator.kind
-                    {
-                        return ctx.functions.get(&const_.ty()).map(|s| s.as_str());
-                    }
-                    None
+                    } => ctx.functions.get(&const_.ty()).map(|s| s.as_str()),
+                    _ => None,
                 })
                 .collect();
             call_graph.insert(&item.symbol_name, callees);
@@ -163,10 +161,7 @@ fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) -> HashSet<
 ///
 /// But not a user-defined `lang_start` e.g. `crate1::something::lang_start`.
 fn is_std_rt_lang_start(kind: &MonoItemKind) -> bool {
-    match kind {
-        MonoItemKind::MonoItemFn { name, .. } => name.contains("std::rt::lang_start"),
-        _ => false,
-    }
+    matches!(kind, MonoItemKind::MonoItemFn { name, .. } if name.contains("std::rt::lang_start"))
 }
 
 // =============================================================================

--- a/src/mk_graph/mod.rs
+++ b/src/mk_graph/mod.rs
@@ -3,12 +3,14 @@
 //! This module provides functionality to generate graph visualizations
 //! of Rust's MIR in various formats (DOT, D2).
 
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::io::{self, Write};
 
 use crate::compat::middle::ty::TyCtxt;
 use crate::compat::output::{mir_output_path, OutputDest};
-use crate::printer::collect_smir;
+use crate::compat::stable_mir::mir::{ConstOperand, Operand, TerminatorKind};
+use crate::printer::{collect_smir, Item, MonoItemKind};
 
 // Sub-modules
 pub mod context;
@@ -31,17 +33,125 @@ pub(crate) fn skip_lang_start() -> bool {
     *VAR.get_or_init(|| std::env::var("SKIP_LANG_START").is_ok())
 }
 
+/// Compute the set of symbol names to exclude from graph rendering.
+/// Excludes `std::rt::lang_start` items and items uniquely downstream
+/// of them (i.e., only reachable through `lang_start` in the call graph).
+///
+/// The algorithm:
+/// 1. Build a call graph from Call terminators
+/// 2. Identify `std::rt::lang_start` seed items (via demangled name of MonoItemFn)
+/// 3. Find entry-point items (not called by any other item)
+/// 4. BFS from non-seed entry points, not entering seed nodes
+/// 5. Everything not reachable gets excluded
+pub(crate) fn compute_lang_start_exclusions(items: &[Item], ctx: &GraphContext) -> HashSet<String> {
+    // Build forward call graph: symbol_name -> list of callee names
+    let mut call_graph: HashMap<&str, Vec<&str>> = HashMap::new();
+    for item in items {
+        if let MonoItemKind::MonoItemFn {
+            body: Some(body), ..
+        } = &item.mono_item_kind
+        {
+            let callees: Vec<&str> = body
+                .blocks
+                .iter()
+                .filter_map(|block| {
+                    if let TerminatorKind::Call {
+                        func: Operand::Constant(ConstOperand { const_, .. }),
+                        ..
+                    } = &block.terminator.kind
+                    {
+                        return ctx.functions.get(&const_.ty()).map(|s| s.as_str());
+                    }
+                    None
+                })
+                .collect();
+            call_graph.insert(&item.symbol_name, callees);
+        }
+    }
+
+    // Identify seed items via the demangled MonoItemFn name containing "std::rt::lang_start".
+    let seed_names: HashSet<&str> = items
+        .iter()
+        .filter(|item| is_std_rt_lang_start(&item.mono_item_kind))
+        .map(|item| item.symbol_name.as_str())
+        .collect();
+
+    // Retrieve all items that were called via a Call terminator
+    let has_callers: HashSet<&str> = call_graph.values().flatten().copied().collect();
+
+    // BFS from non-seed entry points (items with no callers)
+    let mut reachable: HashSet<&str> = HashSet::new();
+    let mut queue: VecDeque<&str> = VecDeque::new();
+
+    for item in items {
+        let name = item.symbol_name.as_str();
+        let is_entry = !has_callers.contains(name);
+        if is_entry && !seed_names.contains(name) {
+            // some items call other items
+            reachable.insert(name);
+            queue.push_back(name);
+        }
+    }
+
+    while let Some(name) = queue.pop_front() {
+        if let Some(callees) = call_graph.get(name) {
+            for &callee in callees {
+                if !reachable.contains(callee) && !seed_names.contains(callee) {
+                    reachable.insert(callee);
+                    queue.push_back(callee);
+                }
+            }
+        }
+    }
+
+    // Everything NOT reachable should be excluded
+    let all_names: HashSet<&str> = items
+        .iter()
+        .map(|i| i.symbol_name.as_str())
+        .chain(ctx.functions.values().map(|s| s.as_str())) // chain external functions too
+        .collect();
+
+    all_names
+        .difference(&reachable)
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Check the demangled MonoItemFn name for `std::rt::lang_start`.
+/// This catches:
+/// - `std::rt::lang_start::<()>` (the runtime entry point)
+/// - `std::rt::lang_start::<()>::{closure#0}` (its closure)
+/// - `<{closure@std::rt::lang_start<()>::{closure#0}} as ...>::call_once` (trait impls referencing it)
+/// - `std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>` (drop glue)
+///
+/// But not a user-defined `lang_start` e.g. `crate1::something::lang_start`.
+fn is_std_rt_lang_start(kind: &MonoItemKind) -> bool {
+    match kind {
+        MonoItemKind::MonoItemFn { name, .. } => name.contains("std::rt::lang_start"),
+        _ => false,
+    }
+}
+
 // =============================================================================
 // Entry Points
 // =============================================================================
 
 /// Entry point to write the DOT file
 pub fn emit_dotfile(tcx: TyCtxt<'_>) {
+    let smir = collect_smir(tcx);
+
     if skip_lang_start() {
-        println!("SKIP_LANG_START is set");
+        let ctx = GraphContext::from_smir(&smir);
+        let excluded = compute_lang_start_exclusions(&smir.items, &ctx);
+        println!("SKIP_LANG_START: excluding {} items:", excluded.len());
+        let mut sorted: Vec<_> = excluded.iter().collect();
+        sorted.sort();
+        for name in sorted {
+            println!("  - {}", name);
+        }
     }
 
-    let smir_dot = collect_smir(tcx).to_dot_file();
+    let smir_dot = smir.to_dot_file();
 
     match mir_output_path(tcx, "smir.dot") {
         OutputDest::Stdout => {

--- a/src/mk_graph/output/d2.rs
+++ b/src/mk_graph/output/d2.rs
@@ -66,7 +66,7 @@ fn render_d2_function(
     out: &mut String,
 ) {
     let fn_id = short_name(name);
-    let display_name = escape_d2(&name_lines(name));
+    let display_name = name_lines(&escape_d2(name));
 
     // Function container
     out.push_str(&format!("{}: {{\n", fn_id));
@@ -131,7 +131,8 @@ fn render_d2_call_edges(
         }
 
         let target_id = short_name(&callee_name);
-        out.push_str(&format!("{}: \"{}\"\n", target_id, escape_d2(&callee_name)));
+        let display = ctx.display_name(&callee_name);
+        out.push_str(&format!("{}: \"{}\"\n", target_id, escape_d2(display)));
         out.push_str(&format!("{}.style.fill: \"#ffe0e0\"\n", target_id));
         out.push_str(&format!("{}.bb{} -> {}: call\n", fn_id, idx, target_id));
     }

--- a/src/mk_graph/output/d2.rs
+++ b/src/mk_graph/output/d2.rs
@@ -1,20 +1,32 @@
 //! D2 diagram format output for MIR graphs.
 
+use std::collections::HashSet;
+
 use crate::compat::stable_mir;
 use stable_mir::mir::TerminatorKind;
 
-use crate::printer::SmirJson;
-use crate::MonoItemKind;
+use crate::printer::{MonoItemKind, SmirJson};
 
 use crate::mk_graph::context::GraphContext;
 use crate::mk_graph::util::{
     escape_d2, is_unqualified, name_lines, short_name, terminator_targets,
 };
+use crate::mk_graph::{compute_lang_start_exclusions, skip_lang_start};
 
 impl SmirJson {
     /// Convert the MIR to D2 diagram format
-    pub fn to_d2_file(self) -> String {
+    pub fn to_d2_file(mut self) -> String {
         let ctx = GraphContext::from_smir(&self);
+
+        // Optionally filter out lang_start items and their unique descendants
+        let excluded: HashSet<String> = if skip_lang_start() {
+            let excluded = compute_lang_start_exclusions(&self.items, &ctx);
+            self.items.retain(|i| !excluded.contains(&i.symbol_name));
+            excluded
+        } else {
+            HashSet::new()
+        };
+
         let mut output = String::new();
 
         output.push_str("direction: right\n\n");
@@ -23,7 +35,7 @@ impl SmirJson {
         for item in self.items {
             match item.mono_item_kind {
                 MonoItemKind::MonoItemFn { name, body, .. } => {
-                    render_d2_function(&name, body.as_ref(), &ctx, &mut output);
+                    render_d2_function(&name, body.as_ref(), &ctx, &excluded, &mut output);
                 }
                 MonoItemKind::MonoItemGlobalAsm { asm } => {
                     render_d2_asm(&asm, &mut output);
@@ -61,6 +73,7 @@ fn render_d2_function(
     name: &str,
     body: Option<&stable_mir::mir::Body>,
     ctx: &GraphContext,
+    excluded: &HashSet<String>,
     out: &mut String,
 ) {
     let fn_id = short_name(name);
@@ -80,7 +93,7 @@ fn render_d2_function(
 
     // Call edges (must be outside the container)
     if let Some(body) = body {
-        render_d2_call_edges(&fn_id, body, ctx, out);
+        render_d2_call_edges(&fn_id, body, ctx, excluded, out);
     }
 }
 
@@ -115,6 +128,7 @@ fn render_d2_call_edges(
     fn_id: &str,
     body: &stable_mir::mir::Body,
     ctx: &GraphContext,
+    excluded: &HashSet<String>,
     out: &mut String,
 ) {
     for (idx, block) in body.blocks.iter().enumerate() {
@@ -124,7 +138,7 @@ fn render_d2_call_edges(
         let Some(callee_name) = ctx.resolve_call_target(func) else {
             continue;
         };
-        if !is_unqualified(&callee_name) {
+        if !is_unqualified(&callee_name) || excluded.contains(&callee_name) {
             continue;
         }
 

--- a/src/mk_graph/output/d2.rs
+++ b/src/mk_graph/output/d2.rs
@@ -1,7 +1,5 @@
 //! D2 diagram format output for MIR graphs.
 
-use std::collections::HashSet;
-
 use crate::compat::stable_mir;
 use stable_mir::mir::TerminatorKind;
 
@@ -11,21 +9,13 @@ use crate::mk_graph::context::GraphContext;
 use crate::mk_graph::util::{
     escape_d2, is_unqualified, name_lines, short_name, terminator_targets,
 };
-use crate::mk_graph::{compute_lang_start_exclusions, skip_lang_start};
+use crate::mk_graph::ItemFilter;
 
 impl SmirJson {
     /// Convert the MIR to D2 diagram format
     pub fn to_d2_file(mut self) -> String {
-        let ctx = GraphContext::from_smir(&self);
-
-        // Optionally filter out lang_start items and their unique descendants
-        let excluded: HashSet<String> = if skip_lang_start() {
-            let excluded = compute_lang_start_exclusions(&self.items, &ctx);
-            self.items.retain(|i| !excluded.contains(&i.symbol_name));
-            excluded
-        } else {
-            HashSet::new()
-        };
+        let mut ctx = GraphContext::from_smir(&self);
+        ItemFilter::apply_all(&mut self.items, &mut ctx);
 
         let mut output = String::new();
 
@@ -35,7 +25,7 @@ impl SmirJson {
         for item in self.items {
             match item.mono_item_kind {
                 MonoItemKind::MonoItemFn { name, body, .. } => {
-                    render_d2_function(&name, body.as_ref(), &ctx, &excluded, &mut output);
+                    render_d2_function(&name, body.as_ref(), &ctx, &mut output);
                 }
                 MonoItemKind::MonoItemGlobalAsm { asm } => {
                     render_d2_asm(&asm, &mut output);
@@ -73,7 +63,6 @@ fn render_d2_function(
     name: &str,
     body: Option<&stable_mir::mir::Body>,
     ctx: &GraphContext,
-    excluded: &HashSet<String>,
     out: &mut String,
 ) {
     let fn_id = short_name(name);
@@ -93,7 +82,7 @@ fn render_d2_function(
 
     // Call edges (must be outside the container)
     if let Some(body) = body {
-        render_d2_call_edges(&fn_id, body, ctx, excluded, out);
+        render_d2_call_edges(&fn_id, body, ctx, out);
     }
 }
 
@@ -128,7 +117,6 @@ fn render_d2_call_edges(
     fn_id: &str,
     body: &stable_mir::mir::Body,
     ctx: &GraphContext,
-    excluded: &HashSet<String>,
     out: &mut String,
 ) {
     for (idx, block) in body.blocks.iter().enumerate() {
@@ -138,7 +126,7 @@ fn render_d2_call_edges(
         let Some(callee_name) = ctx.resolve_call_target(func) else {
             continue;
         };
-        if !is_unqualified(&callee_name) || excluded.contains(&callee_name) {
+        if !is_unqualified(&callee_name) {
             continue;
         }
 

--- a/src/mk_graph/output/dot.rs
+++ b/src/mk_graph/output/dot.rs
@@ -57,13 +57,17 @@ impl SmirJson {
             }
 
             // first create all nodes for functions not in the items list
-            for f in ctx.functions.values() {
-                if !item_names.contains(f) {
-                    graph
-                        .node_named(block_name(f, 0))
-                        .set_label(&name_lines(f))
-                        .set_color(Color::Red);
-                }
+            let mut external_fns: Vec<&String> = ctx
+                .functions
+                .values()
+                .filter(|f| !item_names.contains(*f))
+                .collect();
+            external_fns.sort();
+            for f in external_fns {
+                graph
+                    .node_named(block_name(f, 0))
+                    .set_label(&name_lines(ctx.display_name(f)))
+                    .set_color(Color::Red);
             }
 
             for item in self.items {

--- a/src/mk_graph/output/dot.rs
+++ b/src/mk_graph/output/dot.rs
@@ -12,14 +12,24 @@ use crate::MonoItemKind;
 
 use crate::mk_graph::context::GraphContext;
 use crate::mk_graph::util::{block_name, is_unqualified, name_lines, short_name, GraphLabelString};
+use crate::mk_graph::{compute_lang_start_exclusions, skip_lang_start};
 
 impl SmirJson {
     /// Convert the MIR to DOT (Graphviz) format
-    pub fn to_dot_file(self) -> String {
+    pub fn to_dot_file(mut self) -> String {
         let mut bytes = Vec::new();
 
         // Build context BEFORE consuming self
         let ctx = GraphContext::from_smir(&self);
+
+        // Optionally filter out lang_start items and their unique descendants
+        let excluded: HashSet<String> = if skip_lang_start() {
+            let excluded = compute_lang_start_exclusions(&self.items, &ctx);
+            self.items.retain(|i| !excluded.contains(&i.symbol_name));
+            excluded
+        } else {
+            HashSet::new()
+        };
 
         {
             let mut writer = DotWriter::from(&mut bytes);
@@ -57,7 +67,7 @@ impl SmirJson {
 
             // first create all nodes for functions not in the items list
             for f in ctx.functions.values() {
-                if !item_names.contains(f) {
+                if !item_names.contains(f) && !excluded.contains(f) {
                     graph
                         .node_named(block_name(f, 0))
                         .set_label(&name_lines(f))
@@ -245,6 +255,20 @@ impl SmirJson {
 
                                     match &b.terminator.kind {
                                         TerminatorKind::Call { func, args, .. } => {
+                                            // Skip call edges to excluded nodes
+                                            if let Operand::Constant(ConstOperand {
+                                                const_, ..
+                                            }) = func
+                                            {
+                                                if ctx
+                                                    .functions
+                                                    .get(&const_.ty())
+                                                    .is_some_and(|c| excluded.contains(c))
+                                                {
+                                                    continue;
+                                                }
+                                            }
+
                                             let e = match func {
                                                 Operand::Constant(ConstOperand {
                                                     const_, ..

--- a/src/mk_graph/output/dot.rs
+++ b/src/mk_graph/output/dot.rs
@@ -12,24 +12,15 @@ use crate::MonoItemKind;
 
 use crate::mk_graph::context::GraphContext;
 use crate::mk_graph::util::{block_name, is_unqualified, name_lines, short_name, GraphLabelString};
-use crate::mk_graph::{compute_lang_start_exclusions, skip_lang_start};
+use crate::mk_graph::ItemFilter;
 
 impl SmirJson {
     /// Convert the MIR to DOT (Graphviz) format
     pub fn to_dot_file(mut self) -> String {
         let mut bytes = Vec::new();
 
-        // Build context BEFORE consuming self
-        let ctx = GraphContext::from_smir(&self);
-
-        // Optionally filter out lang_start items and their unique descendants
-        let excluded: HashSet<String> = if skip_lang_start() {
-            let excluded = compute_lang_start_exclusions(&self.items, &ctx);
-            self.items.retain(|i| !excluded.contains(&i.symbol_name));
-            excluded
-        } else {
-            HashSet::new()
-        };
+        let mut ctx = GraphContext::from_smir(&self);
+        ItemFilter::apply_all(&mut self.items, &mut ctx);
 
         {
             let mut writer = DotWriter::from(&mut bytes);
@@ -67,7 +58,7 @@ impl SmirJson {
 
             // first create all nodes for functions not in the items list
             for f in ctx.functions.values() {
-                if !item_names.contains(f) && !excluded.contains(f) {
+                if !item_names.contains(f) {
                     graph
                         .node_named(block_name(f, 0))
                         .set_label(&name_lines(f))
@@ -255,20 +246,6 @@ impl SmirJson {
 
                                     match &b.terminator.kind {
                                         TerminatorKind::Call { func, args, .. } => {
-                                            // Skip call edges to excluded nodes
-                                            if let Operand::Constant(ConstOperand {
-                                                const_, ..
-                                            }) = func
-                                            {
-                                                if ctx
-                                                    .functions
-                                                    .get(&const_.ty())
-                                                    .is_some_and(|c| excluded.contains(c))
-                                                {
-                                                    continue;
-                                                }
-                                            }
-
                                             let e = match func {
                                                 Operand::Constant(ConstOperand {
                                                     const_, ..


### PR DESCRIPTION
### Dirty Deeds Demangled Dirt Cheap

So, this PR does one main thing: it makes the external function nodes in dot/d2 graphs actually readable. Those red boxes have always shown raw mangled symbols (`_ZN4core3fmt3num3imp52_$LT$impl...`), which is not exactly pleasant reading. Turns out `rustc_demangle` is already sitting right there in the sysroot; we just weren't using it.

The new flag is `UNMANGLE=1`, surfaced through Make:

```
make svg UNMANGLE=1
```

It composes with the `SKIPLANGSTART=1` flag (also wired through Make in this PR):

```
make svg UNMANGLE=1 SKIPLANGSTART=1
```

A natural question: does demangling affect graph structure? Turns out, no. Display names are strictly separated from node identity. `ctx.functions` stays mangled (preserving hash-based node IDs), so mangled and unmangled graphs are structurally identical; only labels differ. The `GraphContext` gains a `display_names` map that holds demangled names when the flag is set, and renderers call `display_name()` to get the label for a given node.

A few other things came along for the ride:

- `rustc_demangle` added to the compat layer (it's already available in the sysroot, so this is not a new dependency; just a new `extern crate`)
- External function nodes sorted before emission for deterministic dot output (previously `HashMap` iteration order was causing non-deterministic layouts across runs)
- Both flags wired through a single `GRAPH_ENV` variable in the Makefile
- Fixed double-escaping of `\n` line separators in D2 container labels (`escape_d2` was turning `\n` into `\\n`; swapped call order so escaping happens before line-breaking)
- README updated

Depends on #119 (`dc/remove-lang-start`): the `ItemFilter` enum and `SKIP_LANG_START` support that this branch stacks on.

### Before
<details>
<summary>assert_eq</summary>

![assert_eq smir](https://github.com/user-attachments/assets/606525df-05a6-429d-b7e9-06414f60d37e)

</details>

### After
<details>
<summary>assert_eq</summary>

![assert_eq smir](https://github.com/user-attachments/assets/bdfcd06a-334d-4673-bf6d-3cb651584d7e)

</details>


### Test plan

- `make integration-test` passes (no change to JSON output)
- `make test-skip-lang-start` passes
- `make dot` and `make dot UNMANGLE=1` produce structurally identical dot files (same node IDs, same edges; different labels only)
- `make svg UNMANGLE=1 SKIPLANGSTART=1` produces readable, `lang_start`-free SVGs
- Visual inspection: red external function nodes show `core::panicking::panic::h...` instead of `_ZN4core9panicking5panic17h...`