### PR TITLE
All Nightlies Must Pass

### DIFF
--- a/.github/workflows/test-all-nightlies.yml
+++ b/.github/workflows/test-all-nightlies.yml
@@ -1,0 +1,111 @@
+name: 'Test All Nightlies'
+
+# Verifies that every breakpoint nightly (i.e., every nightly that has a
+# golden-file directory under tests/integration/expected/) builds and passes
+# integration and UI tests.  This is the safety net that catches cfg-gating
+# mistakes: a conditional match arm that compiles on the pinned nightly but
+# not on an older (or newer) one in the supported range.
+#
+# Runs on:
+#   - Weekly (Sunday 04:00 UTC): keeps the matrix green even when the branch
+#     is quiet.
+#   - Manual dispatch: for ad-hoc verification after absorbing new breakpoints.
+#   - Push to master: ensures the supported range is intact on merge.
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'   # every Sunday at 04:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [master, cds/the-curious-case-of-stdlib]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Discover the nightly matrix dynamically from the golden-file directories.
+  # This means adding a new breakpoint nightly (with its golden files) is
+  # sufficient to include it in CI; no workflow file edits needed.
+  # ---------------------------------------------------------------------------
+  enumerate-nightlies:
+    name: 'Enumerate nightlies'
+    runs-on: [self-hosted, linux, normal]
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Build nightly matrix from golden-file directories'
+        id: set-matrix
+        run: |
+          set -euo pipefail
+          # Each directory name under tests/integration/expected/ is a nightly
+          # date string like "nightly-2025-07-15".
+          nightlies=$(
+            ls -1 tests/integration/expected/ \
+              | sort \
+              | jq -Rnc '[inputs | select(length > 0)]'
+          )
+          echo "matrix={\"nightly\":${nightlies}}" >> "$GITHUB_OUTPUT"
+          echo "Discovered nightlies: ${nightlies}"
+
+  # ---------------------------------------------------------------------------
+  # For each nightly: install the toolchain, build, run integration + UI tests.
+  # ---------------------------------------------------------------------------
+  test-nightly:
+    name: '${{ matrix.nightly }}'
+    needs: enumerate-nightlies
+    runs-on: [self-hosted, linux, normal]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.enumerate-nightlies.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Install nightly toolchain'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.nightly }}
+          components: rustc-dev,llvm-tools,rust-src
+
+      - name: 'Build stable-mir-json'
+        run: |
+          RUSTUP_TOOLCHAIN=${{ matrix.nightly }} cargo build -vv
+
+      - name: 'Install jq'
+        uses: dcarbone/install-jq-action@v3
+        with:
+          version: 1.7.1
+          force: true
+
+      - name: 'Run integration tests'
+        run: |
+          RUSTUP_TOOLCHAIN=${{ matrix.nightly }} make integration-test
+
+      - name: 'Derive rustc commit for UI tests'
+        id: rustc-meta
+        run: |
+          set -euo pipefail
+          COMMIT=$(RUSTUP_TOOLCHAIN=${{ matrix.nightly }} rustc -vV | grep 'commit-hash' | cut -d' ' -f2)
+          if [ -z "$COMMIT" ]; then
+            echo "::error::Could not determine rustc commit-hash for ${{ matrix.nightly }}"
+            exit 1
+          fi
+          echo "rustc-commit=$COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: 'Check out Rust repo'
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/rust
+          ref: ${{ steps.rustc-meta.outputs.rustc-commit }}
+          path: rust
+          fetch-depth: 1
+
+      - name: 'Run UI tests'
+        run: |
+          RUSTUP_TOOLCHAIN=${{ matrix.nightly }} RUST_DIR_ROOT=rust make test-ui


### PR DESCRIPTION
We now have per-nightly golden files (PR #144) and per-nightly UI test lists (PR #145), but nothing that actually runs them across the full supported range. If a cfg-gated match arm compiles on the pinned nightly but not on an older one (say, because the breakpoint date is off by a day), we won't find out until someone manually installs that toolchain and builds. That's the gap this PR fills.

A single GitHub Actions workflow (test-all-nightlies.yml) that:

1. Discovers the nightly matrix dynamically from the golden-file directories under tests/integration/expected/. No hardcoded list in the workflow file; adding a new breakpoint nightly (with its golden files) is sufficient to include it in CI.

2. For each nightly in the matrix: installs the toolchain, builds the project, runs integration tests (which auto-select the matching golden files), checks out the rust repo at the corresponding commit, and runs UI tests with the per-nightly override lists.

3. Runs on three triggers: weekly (Sunday 04:00 UTC) to keep the matrix green when the branch is quiet, on push to master, and on manual dispatch for ad-hoc verification after absorbing new breakpoints.

The matrix uses fail-fast: false so that one broken nightly doesn't mask failures in others. Each job is named by its nightly date for easy triage.

### Test plan

- Workflow file passes actionlint (or manual review of the YAML)
- Manual dispatch runs the full matrix successfully
- Adding a new golden-file directory automatically adds a row to the matrix (no workflow edits needed)

